### PR TITLE
Switch to semantic exit codes for CLI#halt

### DIFF
--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -27,7 +27,7 @@ module SCSSLint
         setup_configuration
       rescue NoSuchLinter => ex
         puts ex.message
-        halt(-1)
+        halt(1)
       end
     end
 
@@ -82,12 +82,12 @@ module SCSSLint
       halt(1) if runner.lints.any?
     rescue NoFilesError, NoSuchLinter, Errno::ENOENT => ex
       puts ex.message
-      halt(-1)
+      halt(1)
     rescue => ex
       puts ex.message
       puts ex.backtrace
       puts 'Report this bug at '.yellow + BUG_REPORT_URL.cyan
-      halt(-1)
+      halt(1)
     end
 
   private

--- a/spec/scss_lint/cli_spec.rb
+++ b/spec/scss_lint/cli_spec.rb
@@ -155,7 +155,7 @@ describe SCSSLint::CLI do
       let(:files) { [] }
 
       it 'exits with non-zero status' do
-        subject.should_receive(:halt).with(-1)
+        subject.should_receive(:halt).with(1)
         safe_run
       end
     end
@@ -200,7 +200,7 @@ describe SCSSLint::CLI do
       before { SCSSLint::Runner.stub(:new).and_raise(error) }
 
       it 'exits with a non-zero status' do
-        subject.should_receive(:halt).with(-1)
+        subject.should_receive(:halt).with(1)
         safe_run
       end
 


### PR DESCRIPTION
`CLI#halt` was being invoked in several places with an exit code of -1.
Unix exit codes are traditionally limited to integer args in the range
0-255 [1][2], and out of range exit values result in unexpected
behavior. This commit reverts the error codes to use the catchall error
exit code 1, although if one is feeling fancy an exit of 65 (EX_DATAERR -
input data incorrect) may be valid in some places.

[1] - http://en.wikipedia.org/wiki/Exit_status
[2] - http://tldp.org/LDP/abs/html/exitcodes.html
