### PR TITLE
Correctly detected spacing on nested parentheses.

### DIFF
--- a/lib/scss_lint/linter/space_between_parens.rb
+++ b/lib/scss_lint/linter/space_between_parens.rb
@@ -6,8 +6,10 @@ module SCSSLint
     def visit_root(node)
       @spaces = config['spaces']
       engine.lines.each_with_index do |line, index|
-        line.scan /(\( *[^ ]|[^\s] *\))/ do |match|
-          match.each { |str| check(str, index, engine) }
+        # "(^(\t|\s)*\))?" captures leading spaces and tabs followed by a )
+        # "\( *(?!$)" finds "( " as long as its not EOL
+        line.scan /(^(\t|\s)*\))?(\( *(?!$)| *\))?/ do |match|
+          check(match[2], index, engine) if match[2]
         end
       end
     end

--- a/spec/scss_lint/linter/space_between_parens_spec.rb
+++ b/spec/scss_lint/linter/space_between_parens_spec.rb
@@ -65,6 +65,60 @@ describe SCSSLint::Linter::SpaceBetweenParens do
     it { should_not report_lint }
   end
 
+  context 'when outer parens are space padded' do
+    let(:css) { <<-CSS }
+      p {
+        property: fn( fn2(val1, val2) );
+      }
+    CSS
+
+    it { should report_lint line: 2, count: 2 }
+  end
+
+  context 'when inner parens are space padded' do
+    let(:css) { <<-CSS }
+      p {
+        property: fn(fn2( val1, val2 ));
+      }
+    CSS
+
+    it { should report_lint line: 2, count: 2 }
+  end
+
+  context 'when both parens are not space padded' do
+    let(:css) { <<-CSS }
+      p {
+        property: fn(fn2(val1, val2));
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when both parens are space padded' do
+    let(:css) { <<-CSS }
+      p {
+        property: fn( fn2( val1, val2 ) );
+      }
+    CSS
+
+    it { should report_lint line: 2, count: 4 }
+  end
+
+  context 'when multi level parens are multi-line' do
+    let(:css) { <<-CSS }
+      p {
+        property: fn(
+          fn2(
+            val1, val2
+          )
+        );
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
   context 'when the number of spaces has been explicitly set' do
     let(:linter_config) { { 'spaces' => 1 } }
 
@@ -127,6 +181,60 @@ describe SCSSLint::Linter::SpaceBetweenParens do
 						value
 					);
 				}
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when outer parens are space padded' do
+      let(:css) { <<-CSS }
+        p {
+          property: fn( fn2(val1, val2) );
+        }
+      CSS
+
+      it { should report_lint line: 2, count: 2 }
+    end
+
+    context 'when inner parens are space padded' do
+      let(:css) { <<-CSS }
+        p {
+          property: fn(fn2( val1, val2 ));
+        }
+      CSS
+
+      it { should report_lint line: 2, count: 2 }
+    end
+
+    context 'when both parens are not space padded' do
+      let(:css) { <<-CSS }
+        p {
+          property: fn(fn2(val1, val2));
+        }
+      CSS
+
+      it { should report_lint line: 2, count: 4 }
+    end
+
+    context 'when both parens are space padded' do
+      let(:css) { <<-CSS }
+        p {
+          property: fn( fn2( val1, val2 ) );
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when multi level parens are multi-line' do
+      let(:css) { <<-CSS }
+        p {
+          property: fn(
+            fn2(
+              val1, val2
+            )
+          );
+        }
       CSS
 
       it { should_not report_lint }


### PR DESCRIPTION
My apologies! My previous regex barfed on nested parentheses. I've beefed it up along with beefing up the test suite and running the linter on a larger codebase. No false positives, no false negatives.
