### PR TITLE
add overflow-wrap to list of property names

### DIFF
--- a/lib/scss_lint/linter/property_spelling.rb
+++ b/lib/scss_lint/linter/property_spelling.rb
@@ -193,6 +193,7 @@ module SCSSLint
       outline-width
       overflow
       overflow-style
+      overflow-wrap
       overflow-x
       overflow-y
       padding


### PR DESCRIPTION
While some browsers only accept word-wrap, overflow-wrap is [the W3C standard](http://www.w3.org/TR/css3-text/#overflow-wrap) & shouldn't raise an error. [It's implemented](http://caniuse.com/#feat=wordwrap) in WebKit & Blink browsers.
