### PR TITLE
add case for selector with function call

### DIFF
--- a/lib/scss_lint/linter/single_line_per_selector.rb
+++ b/lib/scss_lint/linter/single_line_per_selector.rb
@@ -15,8 +15,11 @@ module SCSSLint
   private
 
     # A comma is invalid if it starts the line or is not the end of the line
+    # but valid if the comma is inside of a function
     def invalid_comma_placement?(node)
-      normalize_spacing(condense_to_string(node.rule)) =~ /\n,|,[^\n]/
+      match = /\n,|[^,\n]*,[^\n]/.match normalize_spacing(condense_to_string(node.rule))
+      return unless match
+      !(/\(.*,/.match(match[0]))
     end
 
     # Since RuleNode.rule returns an array containing both String and

--- a/spec/scss_lint/linter/single_line_per_selector_spec.rb
+++ b/spec/scss_lint/linter/single_line_per_selector_spec.rb
@@ -89,6 +89,16 @@ describe SCSSLint::Linter::SingleLinePerSelector do
     it { should report_lint line: 1 }
   end
 
+  context 'when rule contains interpolated selectors with nth function' do
+    let(:css) { <<-CSS }
+      $foo: bar baz;
+      \#{nth($foo, 1)}.thing {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
   context 'when rule contains an inline comment' do
     let(:css) { <<-CSS }
       .first,  /* A comment */


### PR DESCRIPTION
The SingleLinePerSelector linter should not report a lint if the interpolated selectors contains a comma inside a function (e.g. nth)

I was not able to do this with a single regex - maybe its possible? Let me know what you think about this implementation. Feedback is more than welcome.
