### PR TITLE
exclude files for a linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ linters:
   Indentation:
     enabled: true
     width: 2
+
+  CapitalizationInSelector:
+    enabled: true
+    exclude:
+      - 'path/to/file.scss'
 ```
 
 All linters have an `enabled` option which can be `true` or `false`, which
@@ -86,7 +91,9 @@ The `exclude` directive allows you to specify a glob pattern of files that
 should not be linted by `scss-lint`. Paths are relative to the location of the
 config file itself if they are not absolute paths. If an inherited file
 specifies the `exclude` directive, the two exclusion lists are combined. Any
-additional exclusions specified via the `--exclude` flag are also combined.
+additional exclusions specified via the `--exclude` flag are also
+combined. If you need to exclude files for a single linter you can also
+write an array of files as `exlcude` into the config section of the linter.
 
 You can also configure `scss-lint` by specifying a file via the `--config`
 flag, but note that this will override any configuration files that `scss-lint`

--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -227,6 +227,12 @@ module SCSSLint
       end
     end
 
+    def excluded_file_for_linter?(file_path, linter)
+      linter_options(linter).fetch('exclude', []).any? do |exclusion_glob|
+        File.fnmatch(exclusion_glob, file_path)
+      end
+    end
+
     def exclude_file(file_path)
       abs_path = File.expand_path(file_path)
 

--- a/lib/scss_lint/runner.rb
+++ b/lib/scss_lint/runner.rb
@@ -34,6 +34,7 @@ module SCSSLint
 
       @linters.each do |linter|
         next unless config.linter_enabled?(linter)
+        next if config.excluded_file_for_linter?(file, linter)
 
         begin
           linter.run(engine, config.linter_options(linter))

--- a/spec/scss_lint/config_spec.rb
+++ b/spec/scss_lint/config_spec.rb
@@ -382,4 +382,46 @@ describe SCSSLint::Config do
       end
     end
   end
+
+  describe '#excluded_file_for_linter?' do
+    include_context 'isolated environment'
+
+    let(:config_dir) { 'path/to' }
+    let(:file_name) { "#{config_dir}/config.yml" }
+    let(:config) { described_class.load(file_name) }
+
+    before do
+      described_class.stub(:load_file_contents)
+                     .with(file_name)
+                     .and_return(config_file)
+    end
+
+    context 'when no exclusion is specified in linter' do
+      let(:config_file) { <<-FILE }
+      linters:
+        FakeConfigLinter:
+          enabled: true
+      FILE
+
+      it 'does not exclude any files' do
+        config.excluded_file_for_linter?('anything/you/want.scss',
+          SCSSLint::Linter::FakeConfigLinter.new).should be_false
+      end
+    end
+
+    context 'when an exclusion is specified in linter' do
+      let(:config_file) { <<-FILE }
+      linters:
+        FakeConfigLinter:
+          enabled: true
+          exclude:
+            - 'anything/you/want.scss'
+      FILE
+
+      it 'exclude file for this linter' do
+        config.excluded_file_for_linter?('anything/you/want.scss',
+          SCSSLint::Linter::FakeConfigLinter.new).should be_true
+      end
+    end
+  end
 end

--- a/spec/scss_lint/runner_spec.rb
+++ b/spec/scss_lint/runner_spec.rb
@@ -66,6 +66,27 @@ describe SCSSLint::Runner do
       end
     end
 
+    context 'when files ere excluded for one linter' do
+      let(:config_options) do
+        {
+          'linters' => {
+            'FakeLinter1' => { 'enabled' => true, 'exclude' => ['dummy1.scss', 'dummy2.scss'] },
+            'FakeLinter2' => { 'enabled' => false },
+          },
+        }
+      end
+
+      before do
+        SCSSLint::Linter::FakeLinter1.any_instance
+                        .stub(:run)
+                        .and_raise(RuntimeError.new('FakeLinter1#run was called'))
+      end
+
+      it 'not run linter 1' do
+        expect { subject }.to_not raise_error
+      end
+    end
+
     context 'when a linter raises an error' do
       let(:backtrace) { %w[file.rb:1 file.rb:2] }
 


### PR DESCRIPTION
The idea is to exclude single files for a linter. With this you can write an array of relative paths to each linter which will be excluded. It perfectly fits my needs, since the files are not in a special directory where I could solve it with a separate config file.

Let me know what you think about it.
