### PR TITLE
add reporter to get plain list of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Command Line Flag         | Description
 --------------------------|----------------------------------------------------
 `-c`/`--config`           | Specify a configuration file to use
 `-e`/`--exclude`          | Exclude one or more files from being linted
-`-f`/`--format`           | Specify the output format (`Default` or `XML`)
+`-f`/`--format`           | Output format (`Default`, `XML`, `Files`)
 `-i`/`--include-linter`   | Specify which linters you specifically want to run
 `-x`/`--exclude-linter`   | Specify which linters you _don't_ want to run
 `-h`/`--help`             | Show command line flag documentation

--- a/lib/scss_lint/reporter/files_reporter.rb
+++ b/lib/scss_lint/reporter/files_reporter.rb
@@ -1,0 +1,8 @@
+module SCSSLint
+  # Reports a single line per file.
+  class Reporter::FilesReporter < Reporter
+    def report_lints
+      lints.map(&:filename).uniq.join("\n") + "\n" if lints.any?
+    end
+  end
+end

--- a/spec/scss_lint/reporter/files_reporter_spec.rb
+++ b/spec/scss_lint/reporter/files_reporter_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe SCSSLint::Reporter::FilesReporter do
+  subject { described_class.new(lints) }
+
+  describe '#report_lints' do
+    context 'when there are no lints' do
+      let(:lints) { [] }
+
+      it 'returns nil' do
+        subject.report_lints.should be_nil
+      end
+    end
+
+    context 'when there are lints' do
+      let(:filenames)    { ['some-filename.scss', 'some-filename.scss', 'other-filename.scss'] }
+      let(:lints) do
+        filenames.each_with_index.map do |filename, index|
+          SCSSLint::Lint.new(filename, 0, '', :warning)
+        end
+      end
+
+      it 'prints each file on its own line' do
+        subject.report_lints.count("\n").should == 2
+      end
+
+      it 'prints a trailing newline' do
+        subject.report_lints[-1].should == "\n"
+      end
+
+      it 'prints the filename for each lint' do
+        filenames.each do |filename|
+          subject.report_lints.scan(/#{filename}/).count.should == 1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use this if you want to open all files in your favorite editor. This
formatter outputs just the names of the files and makes it possible to
do something like: scss-link -f Files | xargs vim
