### PR TITLE
Remove single quotes from duplicate property linter output to fix XML output bug

### DIFF
--- a/lib/scss_lint/linter/duplicate_property.rb
+++ b/lib/scss_lint/linter/duplicate_property.rb
@@ -29,7 +29,7 @@ module SCSSLint
         end
 
         if existing_prop = prop_names[prop_hash]
-          add_lint(prop, "Property '#{name}' already defined on line #{existing_prop.line}")
+          add_lint(prop, "Property `#{name}` already defined on line #{existing_prop.line}")
         else
           prop_names[prop_hash] = prop
         end


### PR DESCRIPTION
- By using single-quotes in the duplicate property linter output, the XML formatter will produce invalid XML, since single-quotes are used for strings in the XML
- Replacing the single-quote with ` fixes this issue and ensures valid XML output
