### PR TITLE
support -moz-osx vendor prefix

### DIFF
--- a/lib/scss_lint/linter/property_sort_order.rb
+++ b/lib/scss_lint/linter/property_sort_order.rb
@@ -13,7 +13,7 @@ module SCSSLint
       sortable_prop_names = sortable_props.map { |child| child.name.join }
 
       sorted_prop_names = sortable_prop_names.map do |name|
-        /^(?<vendor>-\w+-)?(?<property>.+)/ =~ name
+        /^(?<vendor>-\w+(-osx)?-)?(?<property>.+)/ =~ name
         { name: name, vendor: vendor, property: property }
       end.sort { |a, b| compare_properties(a, b) }
          .map { |fields| fields[:name] }

--- a/spec/scss_lint/linter/property_sort_order_spec.rb
+++ b/spec/scss_lint/linter/property_sort_order_spec.rb
@@ -136,6 +136,17 @@ describe SCSSLint::Linter::PropertySortOrder do
     it { should_not report_lint }
   end
 
+  context 'when using -moz-osx vendor-prefixed property' do
+    let(:css) { <<-CSS }
+      p {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
   context 'when vendor properties are ordered out-of-order before the non-prefixed property' do
     let(:css) { <<-CSS }
       p {


### PR DESCRIPTION
Since Firefox 25 the vendor prefix -moz-osx is supported: https://bugzilla.mozilla.org/show_bug.cgi?id=857142#c83

This fixes the property sort order linter with this vendor prefix. Its not nice to have the `-osx` preview part hard coded, but I don't know a better solution.
