### PR TITLE
Fix SpaceBeforeBrace bug for single line blocks #94

### DIFF
--- a/lib/scss_lint/linter/space_before_brace.rb
+++ b/lib/scss_lint/linter/space_before_brace.rb
@@ -5,7 +5,7 @@ module SCSSLint
 
     def visit_root(node)
       engine.lines.each_with_index do |line, index|
-        line.scan /(?<![^ ] )\{$/ do |match|
+        line.scan /[^"](?<![^ ] )\{/ do |match|
           @lints << Lint.new(engine.filename, index + 1, description)
         end
       end

--- a/spec/scss_lint/linter/space_before_brace_spec.rb
+++ b/spec/scss_lint/linter/space_before_brace_spec.rb
@@ -37,4 +37,12 @@ describe SCSSLint::Linter::SpaceBeforeBrace do
 
     it { should_not report_lint }
   end
+
+  context 'issue 94: when .single-line-selector{color: red;}' do
+    let(:css) { <<-CSS }
+      .single-line-selector{color: #f00;}
+    CSS
+
+    it { should report_lint line: 1 }
+  end
 end


### PR DESCRIPTION
For issue 94 https://github.com/causes/scss-lint/issues/94 this fixes
the issue with scss-lint ignoring single line blocks such as:

  .single-line-selector{color: #fff;}

Shane - one concern with this is I'm pretty sure this fix breaks the
rule we have at Causes.com that enforces things like:

  p {
  }

vs

  p {}
