### PR TITLE
 Fix SpaceBeforeBrace bug for interpolations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SCSS-Lint Changelog
 
+# master (unreleased)
+
+* Fix bug in `SpaceBeforeBrace` where it would report a lint for #{...}
+  interpolation erroneously
+
 # 0.20.1
 
 * Fix bug in `SpaceBeforeBrace` where it would not report a lint for

--- a/lib/scss_lint/linter/space_before_brace.rb
+++ b/lib/scss_lint/linter/space_before_brace.rb
@@ -5,7 +5,7 @@ module SCSSLint
 
     def visit_root(node)
       engine.lines.each_with_index do |line, index|
-        line.scan /[^"](?<![^ ] )\{/ do |match|
+        line.scan /[^"#](?<![^ ] )\{/ do |match|
           @lints << Lint.new(engine.filename, index + 1, description)
         end
       end

--- a/spec/scss_lint/linter/space_before_brace_spec.rb
+++ b/spec/scss_lint/linter/space_before_brace_spec.rb
@@ -45,4 +45,17 @@ describe SCSSLint::Linter::SpaceBeforeBrace do
 
     it { should report_lint line: 1 }
   end
+
+  context 'when using #{} interpolation' do
+    let(:css) { <<-CSS }
+      @mixin test-mixin($class, $prop, $pixels) {
+        .\#{$class} {
+          \#{$prop}: \#{$pixels}px;
+        }
+      }
+    CSS
+
+    it { should_not report_lint line: 2 }
+    it { should_not report_lint line: 3 }
+  end
 end


### PR DESCRIPTION
This fixes an issue where `scss-lint` reported a lint for css statements
using interpolations in mixins such as:

  .#{$class}{ #{$property}: 10px;}

The solution was to add the hash to the preceding character exclusion
