### PR TITLE
SpaceBeforeBrace: Add config param to allow extra spaces in single line blocks.

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -77,6 +77,7 @@ linters:
 
   SpaceBeforeBrace:
     enabled: true
+    allow_extra_spaces: false
 
   SpaceBetweenParens:
     enabled: true

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -607,6 +607,19 @@ p {
 }
 ```
 
+Setting `allow_extra_spaces` to `true` allows you to use extra spaces to nicely align single line blocks, so you can write:
+
+```scss
+.icon-chevron-up    { &:before { content: "\e030"; } }
+.icon-chevron-down  { &:before { content: "\e031"; } }
+.icon-chevron-left  { &:before { content: "\e032"; } }
+.icon-chevron-right { &:before { content: "\e033"; } }
+```
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`allow_extra_spaces` | Allow single line blocks to have extra spaces for nicer formatting (default **false**)
+
 ## SpaceBetweenParens
 
 Parentheses should not be padded with spaces.

--- a/lib/scss_lint/linter/space_before_brace.rb
+++ b/lib/scss_lint/linter/space_before_brace.rb
@@ -5,10 +5,31 @@ module SCSSLint
 
     def visit_root(node)
       engine.lines.each_with_index do |line, index|
-        line.scan /[^"#](?<![^ ] )\{/ do |match|
-          add_lint(index + 1, 'Opening curly braces ({) should be preceded by one space')
-        end
+
+        if config['allow_extra_spaces'] && node_on_single_line(node)
+          line.scan /[^"# ]\{/ do |match|
+            add_lint(index + 1, 'Opening curly braces ({) should be preceded by at least one space')
+          end
+        else
+          line.scan /[^"#](?<![^ ] )\{/ do |match|
+            add_lint(index + 1, 'Opening curly braces ({) should be preceded by one space')
+          end
+        end 
       end
+    end
+
+    def node_on_single_line(node)
+      return if node.source_range.start_pos.line != node.source_range.end_pos.line
+
+      # The Sass parser reports an incorrect source range if the trailing curly
+      # brace is on the next line, e.g.
+      #
+      #   p {
+      #   }
+      #
+      # Since we don't want to count this as a single line node, check if the
+      # last character on the first line is an opening curly brace.
+      engine.lines[node.line - 1].strip[-1] != '{'
     end
   end
 end

--- a/spec/scss_lint/linter/space_before_brace_spec.rb
+++ b/spec/scss_lint/linter/space_before_brace_spec.rb
@@ -57,4 +57,33 @@ describe SCSSLint::Linter::SpaceBeforeBrace do
 
     it { should_not report_lint }
   end
+
+  context 'when blocks occupy a single line' do
+    let(:linter_config) { { 'allow_extra_spaces' => allow_extra_spaces } }
+
+    let(:css) { <<-CSS }
+      p{ }
+      p { }
+      p           { &:before { } }
+      p           { &:before{ } }
+    CSS
+
+    context 'and the `allow_extra_spaces` option is true' do
+      let(:allow_extra_spaces) { true }
+      
+      it { should report_lint line: 1 }
+      it { should_not report_lint line: 2 }
+      it { should_not report_lint line: 3 }
+      it { should report_lint line: 4 }
+    end
+
+    context 'and the `allow_extra_spaces` option is false' do
+      let(:allow_extra_spaces) { false }
+
+      it { should report_lint line: 1 }
+      it { should_not report_lint line: 2 }
+      it { should report_lint line: 3 }
+      it { should report_lint line: 4 }
+    end    
+  end
 end


### PR DESCRIPTION
This allows you to space out single line blocks to make the scss more easily scanned by humans:

``` scss
.icon-up            { &:before { content: '^'; } }
.icon-down          { &:before { content: 'v'; } }
.icon-left          { &:before { content: '<'; } }
.icon-right         { &:before { content: '>'; } }
```

My first ever Ruby code, so please let me know if there's a more elegant way to do this!
