### PR TITLE
Add EditorConfig for whitespaceing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Ensure whitespacing for editors with a compatible plug-in.
I ran into this a bit when editing the YAML files as the whitespace wasn't being automatically trimmed.
