### PR TITLE
Add ConfigReporter to generate .scss-lint.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Extend `DuplicateRoot` to `MergeableSelector` linter to check for nested
   rule sets that can be merged in addition to root-level ones
+* Add `ConfigReporter` which returns a configuration where all linters
+  as disabled that caused a lint
 
 ## 0.23.1
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ linters:
 ```
 
 All linters have an `enabled` option which can be `true` or `false`, which
-controls whether the linter is run, along with linter-specific options.  The
+controls whether the linter is run, along with linter-specific options. The
 defaults are defined in `config/default.yml`.
 
 The `inherit_from` directive allows a configuration file to inherit settings
@@ -113,6 +113,12 @@ flag, but note that this will override any configuration files that `scss-lint`
 would normally find on its own (this can be useful for testing a particular
 configuration setting, however). Configurations loaded this way will still be
 merged with the default configuration specified by `config/default.yml`.
+
+To start using `scss-lint` you can use the `Config`
+[Formatter](#formatters) - this will return a configuration where all
+linters are disabeld that caused a lint. Starting with this as your
+`.scss-lint.yml` you can enabled the linters step by step while fixing
+the reported lints.
 
 ## Formatters
 
@@ -142,6 +148,13 @@ scss-lint --format Files | xargs vim
 
 Outputs XML with `<lint>`, `<file>`, and `<issue>` tags. Suitable for
 consumption by tools like [Jenkins](http://jenkins-ci.org/).
+
+### Config
+
+Returns a YAML configuration where all linters are disabled which caused
+a lint. You can use this as a `.scss-lint.yml` file. The point is to
+remove these configuration records one by one while fixing the reported
+lints in the code.
 
 ```
 <?xml version="1.0" encoding="utf-8"?>

--- a/lib/scss_lint/lint.rb
+++ b/lib/scss_lint/lint.rb
@@ -1,13 +1,15 @@
 module SCSSLint
   # Stores information about a single problem that was detected by a [Linter].
   class Lint
-    attr_reader :filename, :location, :description, :severity
+    attr_reader :linter, :filename, :location, :description, :severity
 
+    # @param linter [SCSSLint::Linter]
     # @param filename [String]
     # @param location [SCSSLint::Location]
     # @param description [String]
     # @param severity [Symbol]
-    def initialize(filename, location, description, severity = :warning)
+    def initialize(linter, filename, location, description, severity = :warning)
+      @linter      = linter
       @filename    = filename
       @location    = location
       @description = description

--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -18,21 +18,16 @@ module SCSSLint
       visit(engine.tree)
     end
 
+  protected
+
     # Helper for creating lint from a parse tree node
     #
     # @param node_or_line [Sass::Script::Tree::Node, Sass::Engine::Line]
     # @param message [String]
-    def add_lint(node_or_line, message)
-      location = if node_or_line.respond_to?(:source_range) && node_or_line.source_range
-                   location_from_range(node_or_line.source_range)
-                 elsif node_or_line.respond_to?(:line)
-                   Location.new(node_or_line.line)
-                 else
-                   Location.new(node_or_line)
-                 end
-
-      @lints << Lint.new(engine.filename,
-                         location,
+    def add_lint(node_or_line, message, location = nil)
+      @lints << Lint.new(self,
+                         engine.filename,
+                         location || location_by_node_or_line(node_or_line),
                          message)
     end
 
@@ -128,6 +123,18 @@ module SCSSLint
       parent.children.each do |child|
         child.node_parent = parent
         visit(child)
+      end
+    end
+
+  private
+
+    def location_by_node_or_line(node_or_line)
+      if node_or_line.respond_to?(:source_range) && node_or_line.source_range
+        location_from_range(node_or_line.source_range)
+      elsif node_or_line.respond_to?(:line)
+        Location.new(node_or_line.line)
+      else
+        Location.new(node_or_line)
       end
     end
   end

--- a/lib/scss_lint/linter/space_between_parens.rb
+++ b/lib/scss_lint/linter/space_between_parens.rb
@@ -29,7 +29,7 @@ module SCSSLint
       location = Location.new(index + 1)
       message = "Expected #{pluralize(@spaces, 'space')} " \
                 "between parentheses instead of #{spaces}"
-      @lints << Lint.new(engine.filename, location, message)
+      add_lint(engine.filename, message, location)
     end
   end
 end

--- a/lib/scss_lint/reporter/config_reporter.rb
+++ b/lib/scss_lint/reporter/config_reporter.rb
@@ -1,0 +1,26 @@
+module SCSSLint
+  # Returns a YAML configuration where all linters are disabled which
+  # caused a lint.
+  class Reporter::ConfigReporter < Reporter
+    def report_lints
+      { 'linters' => disabled_linters }.to_yaml unless lints.empty?
+    end
+
+  private
+
+    def disabled_linters
+      linters.each_with_object({}) do |linter, m|
+        m[linter] = { 'enabled' => false }
+      end
+    end
+
+    def linters
+      lints.map { |lint| linter_name(lint.linter) }.compact.uniq.sort
+    end
+
+    def linter_name(linter)
+      return unless linter
+      linter.class.to_s.split('::').last
+    end
+  end
+end

--- a/lib/scss_lint/runner.rb
+++ b/lib/scss_lint/runner.rb
@@ -49,9 +49,9 @@ module SCSSLint
         end
       end
     rescue Sass::SyntaxError => ex
-      @lints << Lint.new(ex.sass_filename, Location.new(ex.sass_line), ex.to_s, :error)
+      @lints << Lint.new(nil, ex.sass_filename, Location.new(ex.sass_line), ex.to_s, :error)
     rescue FileEncodingError => ex
-      @lints << Lint.new(file, Location.new, ex.to_s, :error)
+      @lints << Lint.new(nil, file, Location.new, ex.to_s, :error)
     end
   end
 end

--- a/spec/scss_lint/reporter/config_reporter_spec.rb
+++ b/spec/scss_lint/reporter/config_reporter_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe SCSSLint::Reporter::ConfigReporter do
+  subject { YAML.load(result) }
+  let(:result) { described_class.new(lints).report_lints }
+
+  describe '#report_lints' do
+    context 'when there are no lints' do
+      let(:lints) { [] }
+
+      it 'returns nil' do
+        result.should be_nil
+      end
+    end
+
+    context 'when there are lints' do
+      let(:linters) do
+        [SCSSLint::Linter::FinalNewline, SCSSLint::Linter::BorderZero,
+         SCSSLint::Linter::BorderZero, nil]
+      end
+      let(:lints) do
+        linters.each.map do |linter|
+          SCSSLint::Lint.new(linter ? linter.new : nil, '',
+                             SCSSLint::Location.new, '')
+        end
+      end
+
+      it 'adds one entry per linter' do
+        subject['linters'].size.should eq 2
+      end
+
+      it 'sorts linters by name' do
+        subject['linters'].map(&:first).should eq %w[BorderZero FinalNewline]
+      end
+
+      it 'disables all found linters' do
+        subject['linters']['BorderZero']['enabled'].should eq false
+        subject['linters']['FinalNewline']['enabled'].should eq false
+      end
+    end
+  end
+end

--- a/spec/scss_lint/reporter/default_reporter_spec.rb
+++ b/spec/scss_lint/reporter/default_reporter_spec.rb
@@ -20,7 +20,8 @@ describe SCSSLint::Reporter::DefaultReporter do
       let(:lints) do
         filenames.each_with_index.map do |filename, index|
           location = SCSSLint::Location.new(lines[index])
-          SCSSLint::Lint.new(filename, location, descriptions[index], severities[index])
+          SCSSLint::Lint.new(nil, filename, location, descriptions[index],
+                             severities[index])
         end
       end
 

--- a/spec/scss_lint/reporter/files_reporter_spec.rb
+++ b/spec/scss_lint/reporter/files_reporter_spec.rb
@@ -16,7 +16,7 @@ describe SCSSLint::Reporter::FilesReporter do
       let(:filenames)    { ['some-filename.scss', 'some-filename.scss', 'other-filename.scss'] }
       let(:lints) do
         filenames.map do |filename|
-          SCSSLint::Lint.new(filename, SCSSLint::Location.new, '', :warning)
+          SCSSLint::Lint.new(nil, filename, SCSSLint::Location.new, '')
         end
       end
 

--- a/spec/scss_lint/reporter/xml_reporter_spec.rb
+++ b/spec/scss_lint/reporter/xml_reporter_spec.rb
@@ -43,7 +43,8 @@ describe SCSSLint::Reporter::XMLReporter do
 
       let(:lints) do
         filenames.each_with_index.map do |filename, index|
-          SCSSLint::Lint.new(filename, locations[index], descriptions[index], severities[index])
+          SCSSLint::Lint.new(nil, filename, locations[index],
+                             descriptions[index], severities[index])
         end
       end
 


### PR DESCRIPTION
Returns a YAML configuration where all linters are disabled which caused a lint. You can use this as a `.scss-lint.yml` file. The point is to remove these configuration records one by one while fixing the reported lints in the code.

I think it could be a starting point if you add `scss-lint` to an existing project. There is room for improvements (e.g. excluding single files or suggesting configuration options) but one step after the other. :)

Let me know what you think about this. 
