### PR TITLE
Fix bug in `ZeroUnit` when it is not a dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   configuration file where all linters that caused a lint are disabled
 * Fix bug in `Indentation` linter where `@at-root` directives were not
   treated as an increase in indentation level
+* Fix bug in `ZeroUnit` when it is not a dimension - only for dimensions
+  the unit identifier is optional
 
 ## 0.23.1
 

--- a/lib/scss_lint/linter/zero_unit.rb
+++ b/lib/scss_lint/linter/zero_unit.rb
@@ -7,19 +7,21 @@ module SCSSLint
       return unless node.type == :identifier
 
       node.value.scan(ZERO_UNIT_REGEX) do |match|
+        next unless zero_with_length?(match.first)
         add_lint(node, MESSAGE_FORMAT % match.first)
       end
     end
 
     def visit_script_number(node)
       length = source_from_range(node.source_range)[ZERO_UNIT_REGEX, 1]
+      return unless zero_with_length?(length)
 
-      if node.value == 0 && zero_with_units?(length)
-        add_lint(node, MESSAGE_FORMAT % length)
-      end
+      add_lint(node, MESSAGE_FORMAT % length)
     end
 
   private
+
+    UNITS = %w[em ex ch rem vw vh vmin vmax cm mm in pt pc px]
 
     ZERO_UNIT_REGEX = /
       \b
@@ -30,8 +32,8 @@ module SCSSLint
 
     MESSAGE_FORMAT = '`%s` should be written without units as `0`'
 
-    def zero_with_units?(string)
-      string =~ /^0[a-z]+/
+    def zero_with_length?(string)
+      string =~ /^0([a-z]+)/ && UNITS.include?(Regexp.last_match(1))
     end
   end
 end

--- a/spec/scss_lint/linter/zero_unit_spec.rb
+++ b/spec/scss_lint/linter/zero_unit_spec.rb
@@ -100,4 +100,24 @@ describe SCSSLint::Linter::ZeroUnit do
 
     it { should_not report_lint }
   end
+
+  context 'when properties with zero is a dimension' do
+    let(:css) { <<-CSS }
+      p {
+        transition-delay: 0s;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when mixin include contains a zero value dimension' do
+    let(:css) { <<-CSS }
+      p {
+        @include some-mixin(0s);
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Only for dimensions the unit identifier is optional. This should fix #154
