### PR TITLE
Teach scss-lint --show-formatters.

### DIFF
--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -65,6 +65,10 @@ module SCSSLint
           define_output_format(format)
         end
 
+        opts.on_tail('--show-formatters', 'Shows available formatters') do
+          print_formatters
+        end
+
         opts.on('-i', '--include-linter linter,...', Array,
                 'Specify which linters you want to run') do |linters|
           @options[:included_linters] = linters
@@ -194,6 +198,20 @@ module SCSSLint
     rescue NameError
       puts "Invalid output format specified: #{format}"
       halt :config
+    end
+
+    def print_formatters
+      puts 'Installed formatters:'
+
+      reporter_names = SCSSLint::Reporter.descendants.map do |reporter|
+        reporter.name.split('::').last.split('Reporter').first
+      end
+
+      reporter_names.sort.each do |reporter_name|
+        puts " - #{reporter_name}"
+      end
+
+      halt
     end
 
     def print_linters

--- a/lib/scss_lint/reporter.rb
+++ b/lib/scss_lint/reporter.rb
@@ -3,6 +3,10 @@ module SCSSLint
   class Reporter
     attr_reader :lints
 
+    def self.descendants
+      ObjectSpace.each_object(Class).select { |klass| klass < self }
+    end
+
     def initialize(lints)
       @lints = lints
     end

--- a/spec/scss_lint/cli_spec.rb
+++ b/spec/scss_lint/cli_spec.rb
@@ -116,6 +116,15 @@ describe SCSSLint::CLI do
       end
     end
 
+    context 'when the show formatters flag is set' do
+      let(:flags) { ['--show-formatters'] }
+
+      it 'prints the formatters' do
+        subject.should_receive(:print_formatters)
+        safe_parse
+      end
+    end
+
     context 'when the show linters flag is set' do
       let(:flags) { ['--show-linters'] }
 

--- a/spec/scss_lint/reporter_spec.rb
+++ b/spec/scss_lint/reporter_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe SCSSLint::Reporter do
+  class SCSSLint::Reporter::FakeReporter < SCSSLint::Reporter; end
+
+  describe '#descendants' do
+    it 'contains FakeReporter' do
+      SCSSLint::Reporter.descendants.should include(SCSSLint::Reporter::FakeReporter)
+    end
+  end
+end


### PR DESCRIPTION
Show the installed formatters conveniently on the commandline.

```
$ scss-lint --show-formatters
Installed formatters:
 - Config
 - Default
 - Files
 - XML
```
