### PR TITLE
Teach TrailingSemicolonAfterPropertyValue to not crash on oneline css rules.

### DIFF
--- a/lib/scss_lint/linter/trailing_semicolon_after_property_value.rb
+++ b/lib/scss_lint/linter/trailing_semicolon_after_property_value.rb
@@ -9,12 +9,10 @@ module SCSSLint
 
       unless has_nested_props
         if has_space_before_semicolon?(node)
-          line = node.source_range.end_pos
+          line = node.source_range.start_pos.line
           add_lint line, 'Property declaration should be terminated by a semicolon'
         elsif !ends_with_semicolon?(node)
-          # Adjust line since lack of semicolon results in end of source range
-          # being on the next line
-          line = node.source_range.end_pos.line - 1
+          line = node.source_range.start_pos.line
           add_lint line,
                    'Property declaration should not have a space before ' \
                    'the terminating semicolon'

--- a/spec/scss_lint/linter/trailing_semicolon_after_property_value_spec.rb
+++ b/spec/scss_lint/linter/trailing_semicolon_after_property_value_spec.rb
@@ -107,6 +107,22 @@ describe SCSSLint::Linter::TrailingSemicolonAfterPropertyValue do
       }
     CSS
 
-    it { should report_lint line: 6 }
+    it { should report_lint line: 2 }
+  end
+
+  context 'when a oneline rule does not end with a semicolon' do
+    let(:css) { <<-CSS }
+      .foo { border: 0 }
+    CSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a oneline rule has a space before a semicolon' do
+    let(:css) { <<-CSS }
+      .foo { border: 0 ; }
+    CSS
+
+    it { should report_lint line: 1 }
   end
 end


### PR DESCRIPTION
- Closes #163
