### PR TITLE
Additional test cases for indentation linter

### DIFF
--- a/spec/scss_lint/linter/indentation_spec.rb
+++ b/spec/scss_lint/linter/indentation_spec.rb
@@ -155,4 +155,25 @@ describe SCSSLint::Linter::Indentation do
     it { should report_lint line: 2 }
     it { should_not report_lint line: 3 }
   end
+
+  context 'when there are selectors across multiple lines' do
+    let(:css) { <<-CSS }
+      .class1,
+      .class2 {
+        margin: 0;
+        padding: 5px;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when there are selectors across multiple lines with a single line block' do
+    let(:css) { <<-CSS }
+      .class1,
+      .class2 { margin: 0; }
+    CSS
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Here are two additional test cases for the indentation linter. The first one works fine, the second one fails, which is likely a bug in the linter.

In my project, there are CSS blocks like 

```
.class1,
.class2 { margin: 0; }
```

With the indentation linter turned on, the second line is reported as error and needs to be rewritten as

```
.class1,
  .class2 { margin: 0; }
```

in order to pass the check. That's pretty awful syntax so I assume it's a bug.

Thoughts?
