### PR TITLE
Typo in README.md

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -15,7 +15,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [EmptyRule](#emptyrule)
 * [FinalNewline](#finalnewline)
 * [HexLength](#hexlength)
-* [HexNotation](#hexnotaion)
+* [HexNotation](#hexnotation)
 * [HexValidation](#hexvalidation)
 * [IdWithExtraneousSelector](#idwithextraneousselector)
 * [Indentation](#indentation)


### PR DESCRIPTION
Fixed a small typo in README.md for the anchor links.
