### PR TITLE
Add some additional properties to concentric

### DIFF
--- a/data/property-sort-orders/concentric.txt
+++ b/data/property-sort-orders/concentric.txt
@@ -14,7 +14,7 @@ column-fill
 column-rule
 column-span
 column-count
-coulumn-width
+column-width
 
 float
 clear


### PR DESCRIPTION
I know those can be ignored via the option but, might as well update the standard itself for future reference.
