### PR TITLE
Adding SelectorFormat linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -82,6 +82,10 @@ linters:
     enabled: true
     max_depth: 3
 
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase # or 'snake_case', or 'camel_case', or a regex pattern
+
   Shorthand:
     enabled: true
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -26,6 +26,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [PropertySortOrder](#propertysortorder)
 * [PropertySpelling](#propertyspelling)
 * [SelectorDepth](#selectordepth)
+* [SelectorFormat](#selectorformat)
 * [Shorthand](#shorthand)
 * [SingleLinePerProperty](#singlelineperproperty)
 * [SingleLinePerSelector](#singlelineperselector)
@@ -695,6 +696,34 @@ is better to use less than 3 whenever possible.
 Configuration Option | Description
 ---------------------|---------------------------------------------------------
 `max_depth`          | Maximum depth before reporting errors (default **3**)
+
+## SelectorFormat
+
+It is good practice to choose a convention for naming selectors.
+
+**Good**
+```scss
+// convention: 'hyphenated_lowercase'
+.foo-bar-77, foo-bar, #foo-bar {}
+
+// convention: 'snake_case'
+.foo_bar77, foo_bar, #foo_bar {}
+
+// convention: 'camel_case'
+.fooBar77, fooBar, #fooBar {}
+}
+```
+
+Since you might need to overwrite selectors for third party stylesheets, you
+can you specify `ignored_names` as an array of individual selectors to ignore.
+Another option is to specify `ignored_types` to globally ignore a certain
+type of selector.
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`convention`         | Name of convention to use (`hyphenated_lowercase` (default) or `snake_case` or `camel_case`), or a regex the name must match
+`ignored_names`      | Array of whitelisted names to not report lints for.
+`ignored_types`      | Array containing list of types of selectors to ignore (valid values are `attribute`, `class`, `element`, `id`, `placeholder`, or `pseudo-selector`)
 
 ## Shorthand
 

--- a/lib/scss_lint/linter/selector_format.rb
+++ b/lib/scss_lint/linter/selector_format.rb
@@ -1,0 +1,75 @@
+module SCSSLint
+  # Checks that selector names use a specified convention
+  class Linter::SelectorFormat < Linter
+    include LinterRegistry
+
+    def visit_root(_node)
+      @ignored_names = Array(config['ignored_names']).to_set
+      @ignored_types = Array(config['ignored_types']).to_set
+      yield
+    end
+
+    def visit_attribute(attribute)
+      check(attribute) unless @ignored_types.include?('attribute')
+    end
+
+    def visit_class(klass)
+      check(klass) unless @ignored_types.include?('class')
+    end
+
+    def visit_element(element)
+      check(element) unless @ignored_types.include?('element')
+    end
+
+    def visit_id(id)
+      check(id) unless @ignored_types.include?('id')
+    end
+
+    def visit_placeholder(placeholder)
+      check(placeholder) unless @ignored_types.include?('placeholder')
+    end
+
+    def visit_pseudo(pseudo)
+      check(pseudo) unless @ignored_types.include?('pseudo-selector')
+    end
+
+  private
+
+    def check(node)
+      name = node.name
+
+      return if @ignored_names.include?(name)
+      return unless violation = violated_convention(name)
+
+      add_lint(node, "Selector `#{name}` should be " \
+                     "written #{violation[:explanation]}")
+    end
+
+    CONVENTIONS = {
+      'hyphenated_lowercase' => {
+        explanation: 'in lowercase with hyphens',
+        validator: ->(name) { name !~ /[^\-a-z0-9]/ },
+      },
+      'snake_case' => {
+        explanation: 'in lowercase with underscores',
+        validator: ->(name) { name !~ /[^_a-z0-9]/ },
+      },
+      'camel_case' => {
+        explanation: 'has no spaces with capitalized words except first',
+        validator: ->(name) { name =~ /^[a-z][a-zA-Z0-9]*$/ },
+      },
+    }
+
+    # Checks the given name and returns the violated convention if it failed.
+    def violated_convention(name_string)
+      convention_name = config['convention'] || 'hyphenated_lowercase'
+
+      convention = CONVENTIONS[convention_name] || {
+        explanation: "must match regex /#{convention_name}/",
+        validator: ->(name) { name =~ /#{convention_name}/ }
+      }
+
+      convention unless convention[:validator].call(name_string)
+    end
+  end
+end

--- a/spec/scss_lint/linter/selector_format_spec.rb
+++ b/spec/scss_lint/linter/selector_format_spec.rb
@@ -1,0 +1,270 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::SelectorFormat do
+  context 'when class has alphanumeric chars and is separated by hyphens' do
+    let(:css) { <<-CSS }
+      .foo-bar-77 {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when id has alphanumeric chars and is separated by hyphens' do
+    let(:css) { <<-CSS }
+      #foo-bar-77 {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when element has alphanumeric chars and is separated by hyphens' do
+    let(:css) { <<-CSS }
+      foo-bar-77 {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when placeholder has alphanumeric chars and is separated by hyphens' do
+    let(:css) { <<-CSS }
+      %foo-bar-77 {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when pseudo-selector has alphanumeric chars and is separated by hyphens' do
+    let(:css) { <<-CSS }
+      [foo-bar-77=text] {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when selector has alphanumeric chars and is separated by underscores' do
+    let(:css) { <<-CSS }
+      .foo_bar {
+      }
+    CSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when selector has is in camelCase' do
+    let(:css) { <<-CSS }
+      fooBar77 {
+      }
+    CSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when placeholder has alphanumeric chars and is separated by underscores' do
+    let(:css) { <<-CSS }
+      %foo_bar {
+      }
+    CSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'psuedo-selector has alphanumeric chars and is separated by underscores' do
+    let(:css) { <<-CSS }
+      :foo_bar {
+      }
+    CSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when attribute has alphanumeric chars and is separated by underscores' do
+    let(:css) { <<-CSS }
+      [data_text] {
+      }
+    CSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when attribute selector has alphanumeric chars and is separated by underscores' do
+    let(:css) { <<-CSS }
+      [data-text=some_text] {
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when convention is set to snake_case' do
+    let(:linter_config) { { 'convention' => 'snake_case' } }
+
+    context 'when selector has alphanumeric chars and is separated by underscores' do
+      let(:css) { <<-CSS }
+        .foo_bar_77 {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when selector has alphanumeric chars and is separated by hyphens' do
+      let(:css) { <<-CSS }
+        .foo-bar-77 {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when selector has is in camelCase' do
+      let(:css) { <<-CSS }
+        .fooBar77 {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when convention is set to camel_case' do
+    let(:linter_config) { { 'convention' => 'camel_case' } }
+
+    context 'when selector has is in camelCase' do
+      let(:css) { <<-CSS }
+        .fooBar77 {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when selector capitalizes first word' do
+      let(:css) { <<-CSS }
+        .FooBar77 {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when selector has alphanumeric chars and is separated by underscores' do
+      let(:css) { <<-CSS }
+        .foo_bar_77 {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when selector has alphanumeric chars and is separated by hyphens' do
+      let(:css) { <<-CSS }
+        .foo-bar-77 {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when convention is set to use a regex' do
+    let(:linter_config) { { 'convention' => /^[0-9]*$/ } }
+
+    context 'when selector uses regex properly' do
+      let(:css) { <<-CSS }
+        .1337 {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when selector does not use regex properly' do
+      let(:css) { <<-CSS }
+        .leet {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when ignored names are set' do
+    let(:linter_config) { { 'ignored_names' => ['fooBar'] } }
+
+    context 'it ignores exact string matches' do
+      let(:css) { <<-CSS }
+        fooBar {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when ignored types is set to class' do
+    let(:linter_config) { { 'ignored_types' => ['class'] } }
+
+    context 'it ignores all invalid classes' do
+      let(:css) { <<-CSS }
+        .fooBar {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when ignored types is set to id, element, placeholder, pseudo-selector' do
+    let(:linter_config) { { 'ignored_types' => ['id', 'attribute', 'element', 'placeholder', 'pseudo-selector'] } }
+
+    context 'it ignores all invalid ids' do
+      let(:css) { <<-CSS }
+        #fooBar {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'it ignores all invalid elements' do
+      let(:css) { <<-CSS }
+        fooBar {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'it ignores all invalid placeholders' do
+      let(:css) { <<-CSS }
+        %fooBar {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'it ignores all invalid attributes' do
+      let(:css) { <<-CSS }
+        [fooBar=fooBar] {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'it ignores all invalid pseudo-selectors' do
+      let(:css) { <<-CSS }
+        :fooBar {
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+  end
+end


### PR DESCRIPTION
I piggybacked off of the CapitalizationInSelector and NameFormat linters to create this linter, which adds a convention for all selectors (see the linter class for the regexs used).  Similar to CapitalizationInSelector, it supports `ignored_types` and `ignored_names`.

This linter partially addresses https://github.com/causes/scss-lint/issues/227.
