### PR TITLE
Added BangFormat linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,10 @@
 # Default application configuration that all configurations inherit from.
 linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
   BorderZero:
     enabled: true
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -2,6 +2,7 @@
 
 Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 
+* [BangFormat](#bangformat)
 * [BorderZero](#borderzero)
 * [ColorKeyword](#colorkeyword)
 * [Comment](#comment)
@@ -41,6 +42,27 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [UrlFormat](#urlformat)
 * [UrlQuotes](#urlquotes)
 * [ZeroUnit](#urlquotes)
+
+## BangFormat
+
+Reports when you use improper spacing around `!` (the "bang") in `!important` and `!default` declarations.
+
+You can prefer a single space or no space both before and after the `!`.
+
+**Bad**
+```scss
+color: #000!important;
+```
+
+**Good**
+```scss
+color: #000 !important;
+```
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`space_before_bang`  | Whether a space should be present *before* the `!`, as in `color: #000 !important;` (default **true**)
+`space_after_bang`   | Whether a space should be present *after* the `!`, as in `color: #000 ! important;`
 
 ## BorderZero
 

--- a/lib/scss_lint/linter/bang_format.rb
+++ b/lib/scss_lint/linter/bang_format.rb
@@ -1,0 +1,39 @@
+module SCSSLint
+  # Checks spacing of ! declarations, like !important and !default
+  class Linter::BangFormat < Linter
+    include LinterRegistry
+
+    def visit_prop(node)
+      return unless node.to_sass.include? '!'
+      return unless check_spacing(node)
+      before_qualifier = config['space_before_bang'] ? '' : 'not '
+      after_qualifier = config['space_after_bang'] ? '' : 'not '
+      message = "! should #{before_qualifier}be preceeded by a space, " \
+              "and should #{after_qualifier}be followed by a space"
+      add_lint(node, message)
+    end
+
+  private
+
+    def find_bang_offset(range)
+      offset = 0
+      offset += 1 while character_at(range.start_pos, offset) != '!'
+      offset
+    end
+
+    def check_spacing(node)
+      range = node.value_source_range
+      offset = find_bang_offset(range)
+
+      before_expected = config['space_before_bang'] ? / / : /[^ ]/
+      before_actual = character_at(range.start_pos, offset - 1)
+      before_is_wrong = (before_actual =~ before_expected).nil?
+
+      after_expected = config['space_after_bang'] ? / / : /[^ ]/
+      after_actual = character_at(range.start_pos, offset + 1)
+      after_is_wrong = (after_actual =~ after_expected).nil?
+
+      before_is_wrong || after_is_wrong
+    end
+  end
+end

--- a/spec/scss_lint/linter/bang_format_spec.rb
+++ b/spec/scss_lint/linter/bang_format_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::BangFormat do
+  context 'when no bang is used' do
+    let(:css) { <<-CSS }
+      p {
+        color: #000;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when !important is used correctly' do
+    let(:css) { <<-CSS }
+      p {
+        color: #000 !important;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when !important has no space before' do
+    let(:css) { <<-CSS }
+      p {
+        color: #000!important;
+      }
+    CSS
+
+    it { should report_lint line: 2 }
+  end
+
+  context 'when !important has a space after' do
+    let(:css) { <<-CSS }
+      p {
+        color: #000 ! important;
+      }
+    CSS
+
+    it { should report_lint line: 2 }
+  end
+
+  context 'when !important has a space after and config allows it' do
+    let(:linter_config) { { 'space_before_bang' => true, 'space_after_bang' => true } }
+
+    let(:css) { <<-CSS }
+      p {
+        color: #000 ! important;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when !important has a space before but config does not allow it' do
+    let(:linter_config) { { 'space_before_bang' => false, 'space_after_bang' => true } }
+
+    let(:css) { <<-CSS }
+      p {
+        color: #000 ! important;
+      }
+    CSS
+
+    it { should report_lint line: 2 }
+  end
+
+  context 'when !important has no spaces around and config allows it' do
+    let(:linter_config) { { 'space_before_bang' => false, 'space_after_bang' => false } }
+
+    let(:css) { <<-CSS }
+      p {
+        color: #000!important;
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/causes/scss-lint/issues/244 by checking for space before and after the `!` ("bang"), and allows user to configure on which side(s) they want space.

It does not fully account for @ArmorDarks's examples, however: he also had issues with misspelling of the keywords and spacing between the keywords and the final semicolon. I did not check these because
- I believe the Sass parser will already throw errors with the misspellings, and
- unwanted space before the closing semicolon could be its own linter.

Let me know what you think.
