### PR TITLE
Include the CLI class so we can use it

### DIFF
--- a/lib/scss_lint/rake_task.rb
+++ b/lib/scss_lint/rake_task.rb
@@ -27,6 +27,7 @@ module SCSSLint
     def run_task
       # Lazy load so task doesn't impact load time of Rakefile
       require 'scss_lint'
+      require 'scss_lint/cli'
 
       CLI.new([]).tap do |cli|
         cli.parse_arguments


### PR DESCRIPTION
At the moment using the rake task according to the example fails, due to the `CLI` class not being required.

This fixes that.
