### PR TITLE
Adds to DeclarationOrder mixins and nested rule checking

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -130,7 +130,9 @@ Reports `@debug` statements (which you probably left behind accidentally).
 
 ## DeclarationOrder
 
-Rule sets should be ordered as follows: `@extend` declarations, `@include` declarations without inner `@content`, properties, `@include` declarations *with* inner `@content`, then nested rule sets.
+Rule sets should be ordered as follows: `@extend` declarations, `@include`
+declarations without inner `@content`, properties, `@include` declarations
+*with* inner `@content`, then nested rule sets.
 
 **Bad**
 ```scss
@@ -158,16 +160,20 @@ Rule sets should be ordered as follows: `@extend` declarations, `@include` decla
 }
 ```
 
-The `@extend` statement functionally acts like an inheritance mechanism, which
-means the properties defined by the placeholder being extended are rendered
-before the rest of the properties in the rule set.
+The `@extend` statement functionally acts like an inheritance mechanism,
+which means the properties defined by the placeholder being extended are
+rendered before the rest of the properties in the rule set.
 
-Thus, declaring the `@extend` at the top of the rule set reminds the developer
-of this behavior.
+Thus, declaring the `@extend` at the top of the rule set reminds the
+developer of this behavior.
 
-Placing `@include` declarations without inner `@content` before properties serves to group them with `@extend` declarations and provides the opportunity to overwrite them later in the rule set.
+Placing `@include` declarations without inner `@content` before properties
+serves to group them with `@extend` declarations and provides the opportunity
+to overwrite them later in the rule set.
 
-`@include`s *with* inner `@content` often involve `@media` rules that rely on the cascade or nested rule sets, which justifies their inclusion *after* regular properties.
+`@include`s *with* inner `@content` often involve `@media` rules that rely on
+the cascade or nested rule sets, which justifies their inclusion *after*
+regular properties.
 
 Mixin `@content` and nested rule sets are also linted for declaration order.
 

--- a/lib/scss_lint/linter/declaration_order.rb
+++ b/lib/scss_lint/linter/declaration_order.rb
@@ -3,14 +3,6 @@ module SCSSLint
   class Linter::DeclarationOrder < Linter
     include LinterRegistry
 
-    DECLARATION_ORDER = [
-      Sass::Tree::ExtendNode,
-      Sass::Tree::MixinNode,
-      Sass::Tree::PropNode,
-      'mixin_with_content',
-      Sass::Tree::RuleNode,
-    ]
-
     def visit_rule(node)
       check_node(node)
       yield # Continue linting children
@@ -23,6 +15,16 @@ module SCSSLint
       '@extends, @includes without @content, ' \
       'properties, @includes with @content, ' \
       'nested rule sets'
+
+    MIXIN_WITH_CONTENT = 'mixin_with_content'
+
+    DECLARATION_ORDER = [
+      Sass::Tree::ExtendNode,
+      Sass::Tree::MixinNode,
+      Sass::Tree::PropNode,
+      MIXIN_WITH_CONTENT,
+      Sass::Tree::RuleNode,
+    ]
 
     def important_node?(node)
       DECLARATION_ORDER.include? node.class
@@ -48,7 +50,7 @@ module SCSSLint
       # If the node is a mixin with children, indicate that;
       # otherwise, just return the class.
       return node.class unless node.is_a?(Sass::Tree::MixinNode)
-      'mixin_with_content'
+      MIXIN_WITH_CONTENT
     end
   end
 end

--- a/spec/scss_lint/linter/declaration_order_spec.rb
+++ b/spec/scss_lint/linter/declaration_order_spec.rb
@@ -312,4 +312,255 @@ describe SCSSLint::Linter::DeclarationOrder do
       it { should report_lint }
     end
   end
+
+  context 'when inside a @media query and rule set' do
+    context 'contains @extend before a property' do
+      let(:css) { <<-CSS }
+        @media only screen and (max-width: 1px) {
+          a {
+            @extend foo;
+            color: #f00;
+          }
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'contains @extend after a property' do
+      let(:css) { <<-CSS }
+        @media only screen and (max-width: 1px) {
+          a {
+            color: #f00;
+            @extend foo;
+          }
+        }
+      CSS
+
+      it { should report_lint }
+    end
+
+    context 'contains @extend after nested rule set' do
+      let(:css) { <<-CSS }
+        @media only screen and (max-width: 1px) {
+          a {
+            span {
+              color: #000;
+            }
+            @extend foo;
+          }
+        }
+      CSS
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when a pseudo-element appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        &:hover {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when a pseudo-element appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        &:focus {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a chained selector appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        &.is-active {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a chained selector appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        &.is-active {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when a selector with parent reference appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        .is-active & {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a selector with parent reference appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        .is-active & {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when a pseudo-element appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        &:before {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a pseudo-element appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        &:before {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when a direct descendent appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        > .foo {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a direct descendent appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        > .foo {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when an adjacent sibling appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        & + .foo {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when an adjacent sibling appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        & + .foo {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when a general sibling appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        & ~ .foo {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a general sibling appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        & ~ .foo {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
+
+  context 'when a descendent appears after a property' do
+    let(:css) { <<-CSS }
+      a {
+        color: #fff;
+        .foo {
+          color: #000;
+        }
+      }
+    CSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a descendent appears before a property' do
+    let(:css) { <<-CSS }
+      a {
+        .foo {
+          color: #000;
+        }
+        color: #fff;
+      }
+    CSS
+
+    it { should report_lint }
+  end
 end


### PR DESCRIPTION
This address https://github.com/causes/scss-lint/issues/88 --- but not my modifying PropertySortOrder. Instead, I modified DeclarationOrder to do the following:
- Check for mixin includes without content after extends and before properties
- Check for mixin includes _with_ content after properties and before nested rule sets
- Check the children of mixins with content and nested rule sets the same way the top-level nodes are checked

Fits with @lencioni's suggestions, I think.
