### PR TITLE
More useful PropertySortOrder lint message

### DIFF
--- a/lib/scss_lint/linter/property_sort_order.rb
+++ b/lib/scss_lint/linter/property_sort_order.rb
@@ -26,7 +26,7 @@ module SCSSLint
       sorted_props.each_with_index do |prop, index|
         next unless prop != sortable_prop_info[index]
 
-        add_lint(sortable_props[index], lint_message(sortable_prop_info))
+        add_lint(sortable_props[index], lint_message(sorted_props))
         break
       end
 


### PR DESCRIPTION
Tells you what order it was expecting for the properties. Great for custom orders, so we don't have to compare the order and our SCSS.
