### PR TITLE
Added --require switch to CLI with tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Command Line Flag         | Description
 `-e`/`--exclude`          | Exclude one or more files from being linted
 `-f`/`--format`           | Output format (see [Formatters](#formatters))
 `-o`/`--out`              | Write output to a file instead of STDOUT
+`-r`/`--require`          | Require file/library (mind `$LOAD_PATH`, uses `Kernel.require`)
 `-i`/`--include-linter`   | Specify which linters you specifically want to run
 `-x`/`--exclude-linter`   | Specify which linters you _don't_ want to run
 `-h`/`--help`             | Show command line flag documentation

--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -78,6 +78,10 @@ module SCSSLint
           define_output_path(path)
         end
 
+        opts.on('-r', '--require path', 'Require Ruby file', String) do |path|
+          require path
+        end
+
         opts.on_tail('--show-formatters', 'Shows available formatters') do
           print_formatters
         end

--- a/spec/scss_lint/cli_spec.rb
+++ b/spec/scss_lint/cli_spec.rb
@@ -98,6 +98,15 @@ describe SCSSLint::CLI do
       end
     end
 
+    context 'when the require flag is set' do
+      let(:flags) { %w[--require uri] }
+
+      it 'requires the specified file and constants are accessible' do
+        safe_parse
+        proc { subject.instance_eval %{ URI } }.should_not raise_error
+      end
+    end
+
     context 'when neither format nor out flag is set' do
       let(:flags) { %w[] }
 


### PR DESCRIPTION
Hey,

This feature addition makes it possible, via a CLI switch, to require arbitrary files or libraries into the context prior to reporter execution, making it possible to require custom reporters and other fun extensions. I've included tests, and the addition is relatively simple.

Let me know if something needs modification.

Thanks, cheers!
