### PR TITLE
BangFormat ignores strings; fixes #289

### DIFF
--- a/spec/scss_lint/linter/bang_format_spec.rb
+++ b/spec/scss_lint/linter/bang_format_spec.rb
@@ -76,4 +76,24 @@ describe SCSSLint::Linter::BangFormat do
 
     it { should_not report_lint }
   end
+
+  context 'when ! appears within a string' do
+    let(:css) { <<-CSS }
+      p:before { content: "!important"; }
+      p:before { content: "imp!ortant"; }
+      p:after { content: '!'; }
+      div:before { content: 'important!'; }
+      div:after { content: '  !  '; }
+      p[attr="foo!bar"] {};
+      p[attr='foo!bar'] {};
+      p[attr="!foobar"] {};
+      p[attr='foobar!'] {};
+      $foo: 'bar!';
+      $foo: "bar!";
+      $foo: "!bar";
+      $foo: "b!ar";
+    CSS
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
This prevents BangFormat from complaining about `!` occurrences inside strings of various kinds (content, attributes, variables).

The revision itself was pretty simple, but I also had to divide up methods to satisfy rubocop.
