### PR TITLE
Add UnnecessaryParentReference to README ToC

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -42,6 +42,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [TrailingSemicolon](#trailingsemicolon)
 * [TrailingZero](#trailingzero)
 * [UnnecessaryMantissa](#unnecessarymantissa)
+* [UnnecessaryParentReference](#unnecessaryparentreference)
 * [UrlFormat](#urlformat)
 * [UrlQuotes](#urlquotes)
 * [VendorPrefixes](#vendorprefixes)


### PR DESCRIPTION
The `UnnecessaryParentReference` exists in the document but not in the table of contents.
