### PR TITLE
Add hyphenated_BEM option to Linters Documentation

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -880,7 +880,7 @@ type of selector.
 
 Configuration Option     | Description
 -------------------------|-----------------------------------------------------
-`convention`             | Name of convention to use (`hyphenated_lowercase` (default) or `snake_case`, `camel_case`, or `BEM`), or a regex the name must match
+`convention`             | Name of convention to use (`hyphenated_lowercase` (default) or `snake_case`, `camel_case`, or `BEM`, or `hyphenated_BEM`), or a regex the name must match
 `ignored_names`          | Array of whitelisted names to not report lints for.
 `ignored_types`          | Array containing list of types of selectors to ignore (valid values are `attribute`, `class`, `element`, `id`, `placeholder`, or `pseudo-selector`)
 `attribute_convention`   | Convention for attribute selectors only. See the `convention` option for possible values.


### PR DESCRIPTION
https://github.com/causes/scss-lint/blob/master/CHANGELOG.md#0300

> - Change `BEM` convention of `SelectorFormat` `convention` option to
>   `hyphenated_BEM`, and introduce `BEM` format as specified in
>   https://bem.info/method/definitions/
