### PR TITLE
Fix HexValidation entry in Readme

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -346,7 +346,7 @@ Configuration Option | Description
 
 ## HexValidation
 
-Ensure hexadecimal colors are valid (either three or six digits).
+Ensure hexadecimal colors are valid (either three or six characters).
 
 **Bad**
 ```scss


### PR DESCRIPTION
Colors can include letters, not just digits.
