### PR TITLE
Use line numbers to implement control comments instead of visit order

### DIFF
--- a/lib/scss_lint.rb
+++ b/lib/scss_lint.rb
@@ -7,6 +7,7 @@ require 'scss_lint/lint'
 require 'scss_lint/linter_registry'
 require 'scss_lint/runner'
 require 'scss_lint/selector_visitor'
+require 'scss_lint/control_comments'
 require 'scss_lint/version'
 require 'scss_lint/utils'
 

--- a/lib/scss_lint/control_comments.rb
+++ b/lib/scss_lint/control_comments.rb
@@ -1,0 +1,64 @@
+module SCSSLint
+  # Adds control comment functionality
+  module ControlComments
+    attr_reader :disable_stack, :disabled_lines
+
+  private
+
+    def initialize_vars
+      @disable_stack = [] if @disable_stack.nil?
+      @disabled_lines = Set.new if @disabled_lines.nil?
+    end
+
+    def filter_lints
+      initialize_vars
+
+      @lints = lints.select { |lint| !disabled_lines.include?(lint.location.line) }
+    end
+
+    def enter_visit_control_comment(node)  # rubocop:disable CyclomaticComplexity
+      return unless node.is_a?(Sass::Tree::CommentNode)
+
+      initialize_vars
+
+      match = %r{/* scss\-lint:(disable|enable) (.*?) \*/}.match(node.value[0])
+      return if match.nil?
+
+      linters = match[2].split(/\s*,\s*|\s+/)
+      return unless match[2] == 'all' || linters.include?(name)
+
+      case match[1]
+      when 'disable' then @disable_stack << node
+      when 'enable' then pop_control_comment_stack(node)
+      end
+    end
+
+    def exit_visit_control_comment(node)
+      initialize_vars
+
+      while @disable_stack.last && @disable_stack.last.node_parent == node
+        pop_control_comment_stack(node)
+      end
+    end
+
+    def pop_control_comment_stack(node)
+      comment_node = @disable_stack.pop
+
+      return unless comment_node
+
+      start_line = comment_node.line
+
+      # Find the deepest child that has a line number to which a lint might apply (if it is a
+      # control comment enabe node, it will be the line of the comment itself)
+      child = node
+      loop do
+        break unless child.children.last.is_a?(Sass::Tree::Node)
+        child = child.children.last
+      end
+
+      end_line = child.line
+
+      disabled_lines.merge((start_line..end_line))
+    end
+  end
+end

--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -2,13 +2,13 @@ module SCSSLint
   # Defines common functionality available to all linters.
   class Linter < Sass::Tree::Visitors::Base
     include SelectorVisitor
+    include ControlComments
     include Utils
 
-    attr_reader :config, :engine, :lints, :disable_stack
+    attr_reader :config, :engine, :lints
 
     def initialize
       @lints = []
-      @disable_stack = []
     end
 
     # Run this linter against a parsed document with a given configuration.
@@ -19,6 +19,7 @@ module SCSSLint
       @config = config
       @engine = engine
       visit(engine.tree)
+      filter_lints
     end
 
     # Return the human-friendly name of this linter as specified in the
@@ -34,8 +35,6 @@ module SCSSLint
     # @param node_or_line_or_location [Sass::Script::Tree::Node, Fixnum, SCSSLint::Location]
     # @param message [String]
     def add_lint(node_or_line_or_location, message)
-      return unless @disable_stack.empty?
-
       @lints << Lint.new(self,
                          engine.filename,
                          extract_location(node_or_line_or_location),
@@ -119,18 +118,16 @@ module SCSSLint
     # @param node [Sass::Tree::Node, Sass::Script::Tree::Node,
     #   Sass::Script::Value::Base]
     def visit(node)
-      if node.is_a?(Sass::Tree::CommentNode)
-        parse_control_comment(node)
-      end
-
       # Visit the selector of a rule if parsed rules are available
       if node.is_a?(Sass::Tree::RuleNode) && node.parsed_rules
         visit_selector(node.parsed_rules)
       end
 
+      enter_visit_control_comment(node)
+
       super
 
-      @disable_stack.pop while @disable_stack.last == node
+      exit_visit_control_comment(node)
     end
 
     # Redefine so we can set the `node_parent` of each node
@@ -156,19 +153,6 @@ module SCSSLint
         Location.new(node_or_line_or_location.line)
       else
         Location.new(node_or_line_or_location)
-      end
-    end
-
-    def parse_control_comment(node)
-      match = %r{/* scss\-lint:(disable|enable) (.*?) \*/}.match(node.value[0])
-      return if match.nil?
-
-      linters = match[2].split(/\s*,\s*|\s+/)
-      return unless match[2] == 'all' || linters.include?(name)
-
-      case match[1]
-      when 'disable' then @disable_stack << node.node_parent
-      when 'enable' then @disable_stack.pop
       end
     end
   end


### PR DESCRIPTION
Addresses DuplicateProperty bug reported in #150 

I've split the control comments code into a separate file and removed the brittleness whereby the visit order is crucial to the operation of the control comments. The downside is that it is now brittle to determining the line numbers to which the control comments apply, see lines 49-59 of lib/scss_lint/control_comments.rb to see what I mean.

I've also updated the test to detect this bug.
