### PR TITLE
Bugfix: control comments next to other comments not detected

### DIFF
--- a/lib/scss_lint/control_comment_processor.rb
+++ b/lib/scss_lint/control_comment_processor.rb
@@ -34,6 +34,11 @@ module SCSSLint
       return unless linters.include?('all') || linters.include?(@linter.name)
 
       process_command(match[:command], node)
+
+      # Is the control comment the only thing on this line?
+      return if %r{^\s*(//|/\*)}.match(@linter.engine.lines[node.line - 1])
+
+      pop_control_comment_stack(node)
     end
 
     # Executed after a node has been visited.

--- a/spec/scss_lint/linter_spec.rb
+++ b/spec/scss_lint/linter_spec.rb
@@ -232,5 +232,17 @@ describe SCSSLint::Linter do
 
       it { should_not report_lint }
     end
+
+    context 'when the command comment is at the end of a statement' do
+      let(:css) { <<-CSS }
+        p {
+          border: fail1; // scss-lint:disable Fake
+          border: fail1;
+        }
+      CSS
+
+      it { should_not report_lint line: 2 }
+      it { should report_lint line: 3 }
+    end
   end
 end


### PR DESCRIPTION
Addresses further issues documented in #150 by @acdha

Allows:

```
.foo {
    // Keep the footer anchored on short pages using increasingly accurate/un-supported calculations:
    // scss-lint:disable DuplicateProperty
    min-height: 100%;
    min-height: 90vh;
    min-height: calc(100vh - #{($navbar-height * 2) + $navbar-padding-vertical});
}
```

to lint correctly.
