### PR TITLE
Adds local build instructions to README documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   always report a lint when an ID appears as part of a selector.
 * Fix `DuplicateProperty` to report correct name of duplicated property
 * Add `smacss` sort order option for `PropertySortOrder`
+* Adds local build instructions to the "Contributing" section of README.md.
 
 ## 0.30.0
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,14 @@ Speaking of tests, we use `rspec`, which can be run like so:
 bundle exec rspec
 ```
 
+After you get your unit tests passing you may want to see your version of
+SCSS-Lint in action. You can use Bundler to execute your binary locally from
+within your project's directory:
+
+```bash
+bundle exec bin/scss-lint
+```
+
 ## Changelog
 
 If you're interested in seeing the changes and bug fixes between each version


### PR DESCRIPTION
This is a quick update to the "Contributing" section of the README that adds some instructions on how to test the `scss-lint` binary locally after making a change to your fork or clone.

I was playing around with a local clone of SCSS-Lint and wanted to try using my version of the gem but couldn't find any suggestions on how to build the binary in the project documentation. Thought it might be useful to include a small guide in the documentation to get any potential contributors up and running.

If you have any changes you'd like made to the phrasing or instructions let me know!
