### PR TITLE
Adds leading_underscore option to NameFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   always report a lint when an ID appears as part of a selector.
 * Fix `DuplicateProperty` to report correct name of duplicated property
 * Add `smacss` sort order option for `PropertySortOrder`
+* Adds `leading_underscore` option for `NameFormat`
 
 ## 0.30.0
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -565,6 +565,10 @@ The Sass parser automatically treats underscores and hyphens the same, so even
 if you're using a library that declares a function with an underscore, you can
 refer to it using the hyphenated form instead.
 
+If you use underscores to denote private functions within your Sass, you can set
+the `leading_underscore` option which will enforce all lowercase with hyphens
+but allow a single leading underscore like `@function _private-function() {}`.
+
 You can also prefer the [BEM](http://bem.info/method/) convention by setting the
 `convention` option to `BEM`. Any other value will be treated as a regex.
 

--- a/lib/scss_lint/linter/name_format.rb
+++ b/lib/scss_lint/linter/name_format.rb
@@ -63,6 +63,10 @@ module SCSSLint
         explanation: 'in all lowercase letters with hyphens instead of underscores',
         validator: ->(name) { name !~ /[_A-Z]/ },
       },
+      'leading_underscore' => {
+        explanation: 'hyphenated_lowercase with leading underscores permitted',
+        validator: ->(name) { name !~ /[^_][_A-Z]/ },
+      },
       'BEM' => {
         explanation: 'in BEM (Block Element Modifier) format',
         validator: ->(name) { name !~ /[A-Z]|-{3}|_{3}|[^_]_[^_]/ },

--- a/spec/scss_lint/linter/name_format_spec.rb
+++ b/spec/scss_lint/linter/name_format_spec.rb
@@ -1,167 +1,197 @@
 require 'spec_helper'
 
 describe SCSSLint::Linter::NameFormat do
-  context 'when no variable, functions, or mixin declarations exist' do
-    let(:css) { <<-CSS }
-      p {
-        margin: 0;
-      }
-    CSS
-
-    it { should_not report_lint }
-  end
-
-  context 'when a variable name contains a hyphen' do
-    let(:css) { '$content-padding: 10px;' }
-
-    it { should_not report_lint }
-  end
-
-  context 'when a variable name contains an underscore' do
-    let(:css) { '$content_padding: 10px;' }
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when a variable name contains an uppercase character' do
-    let(:css) { '$contentPadding: 10px;' }
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when a function is declared with a capital letter' do
-    let(:css) { <<-CSS }
-      @function badFunction() {
-      }
-    CSS
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when a function is declared with an underscore' do
-    let(:css) { <<-CSS }
-      @function bad_function() {
-      }
-    CSS
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when a mixin is declared with a capital letter' do
-    let(:css) { <<-CSS }
-      @mixin badMixin() {
-      }
-    CSS
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when a mixin is declared with an underscore' do
-    let(:css) { <<-CSS }
-      @mixin bad_mixin() {
-      }
-    CSS
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when no invalid usages exist' do
-    let(:css) { <<-CSS }
-      p {
-        margin: 0;
-      }
-    CSS
-
-    it { should_not report_lint }
-  end
-
-  context 'when a referenced variable name has a capital letter' do
-    let(:css) { <<-CSS }
-      p {
-        margin: $badVar;
-      }
-    CSS
-
-    it { should report_lint line: 2 }
-  end
-
-  context 'when a referenced variable name has an underscore' do
-    let(:css) { <<-CSS }
-      p {
-        margin: $bad_var;
-      }
-    CSS
-
-    it { should report_lint line: 2 }
-  end
-
-  context 'when a referenced function name has a capital letter' do
-    let(:css) { <<-CSS }
-      p {
-        margin: badFunc();
-      }
-    CSS
-
-    it { should report_lint line: 2 }
-  end
-
-  context 'when a referenced function name has an underscore' do
-    let(:css) { <<-CSS }
-      p {
-        margin: bad_func();
-      }
-    CSS
-
-    it { should report_lint line: 2 }
-  end
-
-  context 'when an included mixin name has a capital letter' do
-    let(:css) { '@include badMixin();' }
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when an included mixin name has an underscore' do
-    let(:css) { '@include bad_mixin();' }
-
-    it { should report_lint line: 1 }
-  end
-
-  context 'when function is a transform function' do
-    %w[rotateX rotateY rotateZ
-       scaleX scaleY scaleZ
-       skewX skewY
-       translateX translateY translateZ].each do |function|
+  shared_examples 'hyphenated_lowercase' do
+    context 'when no variable, functions, or mixin declarations exist' do
       let(:css) { <<-CSS }
         p {
-          transform: #{function}(2);
+          margin: 0;
         }
       CSS
 
       it { should_not report_lint }
     end
+
+    context 'when a variable name contains a hyphen' do
+      let(:css) { '$content-padding: 10px;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a variable name contains an underscore' do
+      let(:css) { '$content_padding: 10px;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when a variable name contains an uppercase character' do
+      let(:css) { '$contentPadding: 10px;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when a function is declared with a capital letter' do
+      let(:css) { <<-CSS }
+        @function badFunction() {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when a function is declared with an underscore' do
+      let(:css) { <<-CSS }
+        @function bad_function() {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when a mixin is declared with a capital letter' do
+      let(:css) { <<-CSS }
+        @mixin badMixin() {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when a mixin is declared with an underscore' do
+      let(:css) { <<-CSS }
+        @mixin bad_mixin() {
+        }
+      CSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when no invalid usages exist' do
+      let(:css) { <<-CSS }
+        p {
+          margin: 0;
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when a referenced variable name has a capital letter' do
+      let(:css) { <<-CSS }
+        p {
+          margin: $badVar;
+        }
+      CSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when a referenced variable name has an underscore' do
+      let(:css) { <<-CSS }
+        p {
+          margin: $bad_var;
+        }
+      CSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when a referenced function name has a capital letter' do
+      let(:css) { <<-CSS }
+        p {
+          margin: badFunc();
+        }
+      CSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when a referenced function name has an underscore' do
+      let(:css) { <<-CSS }
+        p {
+          margin: bad_func();
+        }
+      CSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when an included mixin name has a capital letter' do
+      let(:css) { '@include badMixin();' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when an included mixin name has an underscore' do
+      let(:css) { '@include bad_mixin();' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when function is a transform function' do
+      %w[rotateX rotateY rotateZ
+         scaleX scaleY scaleZ
+         skewX skewY
+         translateX translateY translateZ].each do |function|
+        let(:css) { <<-CSS }
+          p {
+            transform: #{function}(2);
+          }
+        CSS
+
+        it { should_not report_lint }
+      end
+    end
+
+    context 'when mixin is a transform function' do
+      let(:css) { <<-CSS }
+        p {
+          @include translateX(2);
+        }
+      CSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when a mixin contains keyword arguments with underscores' do
+      let(:css) { '@include mixin($some_var: 4);' }
+
+      it { should report_lint }
+    end
+
+    context 'when a mixin contains keyword arguments with hyphens' do
+      let(:css) { '@include mixin($some-var: 4);' }
+
+      it { should_not report_lint }
+    end
   end
 
-  context 'when mixin is a transform function' do
-    let(:css) { <<-CSS }
-      p {
-        @include translateX(2);
-      }
-    CSS
+  context 'when no configuration is specified' do
+    it_behaves_like 'hyphenated_lowercase'
 
-    it { should_not report_lint }
+    context 'when a name contains a leading underscore' do
+      let(:css) { <<-CSS }
+        @function _private-method() {
+        }
+      CSS
+
+      it { should report_lint }
+    end
   end
 
-  context 'when a mixin contains keyword arguments with underscores' do
-    let(:css) { '@include mixin($some_var: 4);' }
+  context 'when the leading underscore style is specified' do
+    let(:linter_config) { { 'convention' => 'leading_underscore' } }
 
-    it { should report_lint }
-  end
+    it_behaves_like 'hyphenated_lowercase'
 
-  context 'when a mixin contains keyword arguments with hyphens' do
-    let(:css) { '@include mixin($some-var: 4);' }
+    context 'when a name contains a leading underscore' do
+      let(:css) { <<-CSS }
+        @function _private-method() {
+        }
+      CSS
 
-    it { should_not report_lint }
+      it { should_not report_lint }
+    end
   end
 
   context 'when the BEM convention is specified' do


### PR DESCRIPTION
This pull request adds support for allowing leading underscores to [denote private functions](https://github.com/thoughtbot/bourbon/blob/502c2108dea1970ffeb4f91cb95b545d67bddfd0/app/assets/stylesheets/helpers/_linear-angle-parser.scss#L2) while otherwise enforcing `hyphenated_lowercase`. It simply adds a `leading_underscore` convention option to `NameFormat`.

The visual diff of the unit tests look a little scary because the indentation changed. Here's what was updated:
1. I [wrapped the default `hyphenated_lowercase` examples](https://github.com/mmwtsn/scss-lint/blob/72df38ba8d8b42d65be82f861381b6bc37209551/spec/scss_lint/linter/name_format_spec.rb#L4) within a Rspec `shared_examples` group so that they could be called by both `hyphenated_lowercase` and `leading_underscore` as the majority of those unit tests are the same.
2. I then [called the shared example and added a function with a leading underscore](https://github.com/mmwtsn/scss-lint/blob/72df38ba8d8b42d65be82f861381b6bc37209551/spec/scss_lint/linter/name_format_spec.rb#L169-L195) to both the default and `leading_underscore` contexts to ensure that `@function _private-function() {}` is flagged by `hyphenated_lowercase` but not by `leading_underscore`.

Let me know if you have any suggestions! Thanks.
