### PR TITLE
also build on JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.1.0
   - 2.1.1
   - 2.1.2
+  - jruby-19mode
 
 script:
   - bundle exec rspec


### PR DESCRIPTION
Because I want to integrate this gem into a [Maven plugin](https://github.com/GeoDienstenCentrum/sass-maven-plugin) I want to be sure that it will run/build on JRuby. 

I thought about extending the build matrix with various JDK implementations, but that seems unnecessary overhead ATM.

see GeoDienstenCentrum/sass-maven-plugin#3
