### PR TITLE
Add allowed_shorthands option to Shorthands linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -137,6 +137,7 @@ linters:
 
   Shorthand:
     enabled: true
+    allowed_shorthands: [1, 2, 3]
 
   SingleLinePerProperty:
     enabled: true

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -1074,6 +1074,13 @@ margin: 1px 1px 1px 1px;
 margin: 1px;
 ```
 
+If you don't want to allow all possible shorthands, you can limit them by
+setting the `allowed_shorthands` array option to a subset of `[1, 2, 3]`.
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`allowed_shorthands` | Array of allowed shorthand lengths (default `[1, 2, 3]`)
+
 ## SingleLinePerProperty
 
 Properties within rule sets should each reside on their own line.

--- a/lib/scss_lint/linter/shorthand.rb
+++ b/lib/scss_lint/linter/shorthand.rb
@@ -72,7 +72,7 @@ module SCSSLint
         [top]
       elsif can_condense_to_two_values(top, right, bottom, left)
         [top, right]
-      elsif right == left
+      elsif can_condense_to_three_values(top, right, bottom, left)
         [top, right, bottom]
       else
         [top, right, bottom, left].compact
@@ -80,6 +80,7 @@ module SCSSLint
     end
 
     def can_condense_to_one_value(top, right, bottom, left)
+      return unless allowed(1)
       return unless top == right
 
       top == bottom && (bottom == left || left.nil?) ||
@@ -87,8 +88,20 @@ module SCSSLint
     end
 
     def can_condense_to_two_values(top, right, bottom, left)
+      return unless allowed(2)
+
       top == bottom && right == left ||
         top == bottom && left.nil? && top != right
+    end
+
+    def can_condense_to_three_values(top, right, bottom, left)
+      return unless allowed(3)
+
+      right == left
+    end
+
+    def allowed(size)
+      config['allowed_shorthands'] && config['allowed_shorthands'].map(&:to_i).include?(size)
     end
   end
 end

--- a/spec/scss_lint/linter/shorthand_spec.rb
+++ b/spec/scss_lint/linter/shorthand_spec.rb
@@ -169,4 +169,30 @@ describe SCSSLint::Linter::Shorthand do
       it { should report_lint line: 3 }
     end
   end
+
+  context 'when configured with allowed_shorthands, and a rule' do
+    let(:linter_config) { { 'allowed_shorthands' => allowed } }
+
+    context 'can be shortened to 1, 2, or 3, but 1 is not allowed' do
+      let(:allowed) { [2, 4] }
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 4px 4px 4px 4px;
+        }
+      SCSS
+
+      it { should report_lint }
+    end
+
+    context 'can be shortened to 1, but 1 is not allowed' do
+      let(:allowed) { [4] }
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 4px 4px 4px;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #392 

Uses @sds's recommended API:

```yaml
linters:
  Shorthand:
    allowed_shorthands: [1, 4]
```