### PR TITLE
Fix RuboCop warnings

### DIFF
--- a/lib/scss_lint/linter/shorthand.rb
+++ b/lib/scss_lint/linter/shorthand.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/CyclomaticComplexity
 module SCSSLint
   # Checks for the use of the shortest form for properties that can be written
   # in shorthand.

--- a/spec/scss_lint/linter/comment_spec.rb
+++ b/spec/scss_lint/linter/comment_spec.rb
@@ -54,7 +54,7 @@ describe SCSSLint::Linter::Comment do
   end
 
   context 'when multi-line comment is allowed by config' do
-    let(:linter_config) { { 'allowed' => "^[/\\* ]*Copyright" } }
+    let(:linter_config) { { 'allowed' => '^[/\\* ]*Copyright' } }
     let(:scss) { <<-SCSS }
       /* Copyright someone. */
       a {
@@ -66,7 +66,7 @@ describe SCSSLint::Linter::Comment do
   end
 
   context 'when multi-line comment is not allowed by config' do
-    let(:linter_config) { { 'allowed' => "^[/\\* ]*Copyright" } }
+    let(:linter_config) { { 'allowed' => '^[/\\* ]*Copyright' } }
     let(:scss) { <<-SCSS }
       /* Other multiline. */
       p {


### PR DESCRIPTION
These snuck through because Travis didn't warn us about build failures.

Submitting this as a pull request to test Travis integration.