### PR TITLE
Ignore currentColor in VariableForProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   multi-line comments, such as copyright notices
 * Fix bug where control comments could filter out lints from other files
   depending on scan order
-* Ignore `inherit` and `transparent` values in `VariableForProperty`
+* Ignore `currentColor`, `inherit`, and `transparent` values in
+  `VariableForProperty`
 
 ## 0.37.0
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -1486,8 +1486,8 @@ linters:
       - font
 ```
 
-Note that values like `inherit` and `transparent` will not be reported, as they
-are special kinds of values that convey additional meaning.
+Note that values like `currentColor`, `inherit`, and `transparent` will not be
+reported, as they are special kinds of values that convey additional meaning.
 
 Configuration Option | Description
 ---------------------|---------------------------------------------------------

--- a/lib/scss_lint/linter/variable_for_property.rb
+++ b/lib/scss_lint/linter/variable_for_property.rb
@@ -3,7 +3,7 @@ module SCSSLint
   class Linter::VariableForProperty < Linter
     include LinterRegistry
 
-    IGNORED_VALUES = %w[inherit transparent]
+    IGNORED_VALUES = %w[currentColor inherit transparent]
 
     def visit_root(_node)
       @properties = Set.new(config['properties'])

--- a/spec/scss_lint/linter/variable_for_property_spec.rb
+++ b/spec/scss_lint/linter/variable_for_property_spec.rb
@@ -88,6 +88,16 @@ describe SCSSLint::Linter::VariableForProperty do
       it { should report_lint line: 3 }
     end
 
+    context 'when property specifies `currentColor`' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-color: currentColor;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
     context 'when property specifies `inherit`' do
       let(:scss) { <<-SCSS }
         p {


### PR DESCRIPTION
Similar to 5a8cac9a2, this value is somewhat special and shouldn't be
considered as breaking the rules of this linter.

More information on the currentColor keyword can be found at:

  https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentColor_keyword

Addresses #426.