### PR TITLE
Add a linter that checks the number of elements in a BEM selector

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,10 @@ linters:
     space_before_bang: true
     space_after_bang: false
 
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
   BorderZero:
     enabled: true
     convention: zero # or `none`

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -3,6 +3,7 @@
 Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 
 * [BangFormat](#bangformat)
+* [BemDepth](#bemdepth)
 * [BorderZero](#borderzero)
 * [ColorKeyword](#colorkeyword)
 * [ColorVariable](#colorvariable)
@@ -73,6 +74,29 @@ Configuration Option | Description
 ---------------------|---------------------------------------------------------
 `space_before_bang`  | Whether a space should be present *before* the `!`, as in `color: #000 !important;` (default **true**)
 `space_after_bang`   | Whether a space should be present *after* the `!`, as in `color: #000 ! important;` (default **false**)
+
+## BemDepth
+
+Reports when a BEM selector contains more elements than a configurable
+maximum number.
+
+**Bad**
+```scss
+.block__element__subelement  {
+  ...
+}
+```
+
+**Good**
+```scss
+.block__element {
+  ...
+}
+```
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`max_elements`       | Maximum number of elements allowed in a BEM selector (default **1**)
 
 ## BorderZero
 

--- a/lib/scss_lint/linter/bem_depth.rb
+++ b/lib/scss_lint/linter/bem_depth.rb
@@ -1,0 +1,31 @@
+module SCSSLint
+  # Checks for BEM selectors with more elements than a specified maximum number.
+  class Linter::BemDepth < Linter
+    include LinterRegistry
+
+    def visit_root(_node)
+      @max_elements = config['max_elements']
+      yield # Continue linting children
+    end
+
+    def visit_class(klass)
+      check_depth(klass, 'selectors')
+    end
+
+    def visit_placeholder(placeholder)
+      check_depth(placeholder, 'placeholders')
+    end
+
+  private
+
+    def check_depth(node, plural_type)
+      selector = node.name
+      parts = selector.split('__')
+      num_elements = (parts[1..-1] || []).length
+      if num_elements > @max_elements
+        add_lint(node, "BEM #{plural_type} should have no more than #{pluralize(@max_elements, 'element')}, but had #{num_elements}")
+      end
+    end
+
+  end
+end

--- a/lib/scss_lint/linter/bem_depth.rb
+++ b/lib/scss_lint/linter/bem_depth.rb
@@ -23,7 +23,7 @@ module SCSSLint
       parts = selector.split('__')
       num_elements = (parts[1..-1] || []).length
       if num_elements > @max_elements
-        add_lint(node, "BEM #{plural_type} should have no more than #{pluralize(@max_elements, 'element')}, but had #{num_elements}")
+        add_lint(node, "BEM #{plural_type} should have no more than #{pluralize(@max_elements, 'element')}, but `#{selector}` has #{num_elements}")
       end
     end
 

--- a/lib/scss_lint/linter/bem_depth.rb
+++ b/lib/scss_lint/linter/bem_depth.rb
@@ -22,10 +22,11 @@ module SCSSLint
       selector = node.name
       parts = selector.split('__')
       num_elements = (parts[1..-1] || []).length
-      if num_elements > @max_elements
-        add_lint(node, "BEM #{plural_type} should have no more than #{pluralize(@max_elements, 'element')}, but `#{selector}` has #{num_elements}")
-      end
-    end
+      return if num_elements <= @max_elements
 
+      found_elements = pluralize(@max_elements, 'element')
+      add_lint(node, "BEM #{plural_type} should have no more than #{found_elements}, " \
+                     "but `#{selector}` has #{num_elements}")
+    end
   end
 end

--- a/spec/scss_lint/linter/bem_depth_spec.rb
+++ b/spec/scss_lint/linter/bem_depth_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::BemDepth do
+  context 'with the default maximum number of elements' do
+
+    context 'when a selector lacks elements' do
+      let(:scss) { <<-SCSS }
+        .block {
+          background: #f00;
+        }
+        %block {
+          background: #0f0;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when a selector contains one element' do
+      let(:scss) { <<-SCSS }
+        .block__element {
+          background: #f00;
+        }
+        %block__element {
+          background: #f00;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when a selector contains one element with a modifier' do
+      let(:scss) { <<-SCSS }
+        .block__element--modifier {
+          background: #f00;
+        }
+        %block__element--modifier {
+          background: #f00;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when a selector contains more than one element' do
+      let(:scss) { <<-SCSS }
+        .block__element__subelement {
+          background: #f00;
+        }
+        %block__element__subelement {
+          background: #f00;
+        }
+      SCSS
+
+      it { should report_lint line: 1 }
+      it { should report_lint line: 4 }
+    end
+
+    context 'when a selector contains more than one element with a modifier' do
+      let(:scss) { <<-SCSS }
+        .block__element__subelement--modifier {
+          background: #f00;
+        }
+        %block__element__subelement--modifier {
+          background: #f00;
+        }
+      SCSS
+
+      it { should report_lint line: 1 }
+      it { should report_lint line: 4 }
+    end
+
+  end
+
+  context 'with a custom maximum number of elements' do
+    let(:linter_config) { { 'max_elements' => 2 } }
+
+    context 'when selectors have up to the custom number of elements' do
+      let(:scss) { <<-SCSS }
+        .block__element__subelement {
+          background: #f00;
+        }
+        %block__element__subelement {
+          background: #f00;
+        }
+        .block__element__subelement--modifier {
+          background: #0f0;
+        }
+        %block__element__subelement--modifier {
+          background: #0f0;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when selectors have more than the custom number of elements' do
+      let(:scss) { <<-SCSS }
+        .block__element__subelement__other {
+          background: #f00;
+        }
+        %block__element__subelement__other {
+          background: #f00;
+        }
+        .block__element__subelement__other--modifier {
+          background: #0f0;
+        }
+        %block__element__subelement__other--modifier {
+          background: #0f0;
+        }
+      SCSS
+
+      it { should report_lint line: 1 }
+      it { should report_lint line: 4 }
+      it { should report_lint line: 7 }
+      it { should report_lint line: 10 }
+    end
+
+  end
+end

--- a/spec/scss_lint/linter/bem_depth_spec.rb
+++ b/spec/scss_lint/linter/bem_depth_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe SCSSLint::Linter::BemDepth do
   context 'with the default maximum number of elements' do
-
     context 'when a selector lacks elements' do
       let(:scss) { <<-SCSS }
         .block {
@@ -69,7 +68,6 @@ describe SCSSLint::Linter::BemDepth do
       it { should report_lint line: 1 }
       it { should report_lint line: 4 }
     end
-
   end
 
   context 'with a custom maximum number of elements' do
@@ -115,6 +113,5 @@ describe SCSSLint::Linter::BemDepth do
       it { should report_lint line: 7 }
       it { should report_lint line: 10 }
     end
-
   end
 end


### PR DESCRIPTION
This linter is disabled by default, allowing users to opt in to the linting if they are using BEM.  This defaults to allowing a single element, but can be configured to enable subelements by changing the
`max_elements` value.