### PR TITLE
Added the ability to load config from the user's home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `Indentation` to not report `@import` directives spread across multiple
   lines
+* Add the ability to load config from the current user's home directory.
 
 ## 0.38.0
 

--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -101,6 +101,8 @@ module SCSSLint
           Config.load(options[:config_file])
         elsif File.exist?(Config::FILE_NAME)
           Config.load(Config::FILE_NAME)
+        elsif File.exist?(Config::USER_FILE)
+          Config.load(Config::USER_FILE)
         else
           Config.default
         end

--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -4,6 +4,7 @@ module SCSSLint
   # Loads and manages application configuration.
   class Config
     FILE_NAME = '.scss-lint.yml'
+    USER_FILE = File.join(Dir.home, FILE_NAME)
     DEFAULT_FILE = File.join(SCSS_LINT_HOME, 'config', 'default.yml')
 
     attr_reader :options, :warnings


### PR DESCRIPTION
This changes the way that config loading works, so that in addition to
checking in the current directory for a config file, scss-lint will also
check in the user's home directory, and load .scss-lint.yml from there
instead if it exists.

This changes the precedence of config loading to:

1. Command line argument
2. .scss-lint.yml in current directory
3. .scss-lint.yml in home directory
4. Config file packaged in the gem

In all cases only the config file loaded is used - config from multiple
files is not merged together.

Fixes #436