### PR TITLE
Fixing YAML file so syck can parse it

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -112,8 +112,7 @@ linters:
       'ms', 's',                               # Duration
       'Hz', 'kHz',                             # Frequency
       'dpi', 'dpcm', 'dppx',                   # Resolution
-      '%',                                     # Other
-    ]
+      '%']                                     # Other
     properties: {}
 
   PropertySortOrder:


### PR DESCRIPTION
The syck YAML parser vomits on the current default YAML file, because of the trailing square bracket in the PropertyUnits linter. Moving it up a level makes it happy.