### PR TITLE
Allow configurable linter plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,42 @@ scss-lint --require=scss_lint_reporter_checkstyle --format=Checkstyle [scss-file
 </checkstyle>
 ```
 
+#### Linters
+
+By default `scss-lint` will load linters from `.scss-linter-plugins` in the root of
+your repository. You can customise the loaded directories by setting `plugin_directories`
+in your `.scss-lint.yml` configuration file. Simply create your linter indentical in structure
+to the https://github.com/brigade/scss-lint/tree/master/lib/scss_lint/linter directory, they will be enabled by default but configuration can be overriden in your `.scss-lint.yml`.
+
+```ruby
+# .scss-linter-plugins/another_linter.rb
+
+module SCSSLint
+  class Linter::AnotherLinter < Linter
+    include LinterRegistry
+  end
+end
+```
+
+```yaml
+# .scss-lint.yml
+plugin_directories: ['.scss-lint-plugins', '.another_directory', '/absolute/path']
+
+linters:
+  AnotherLinter:
+    enabled: true
+```
+
+You can also load linters packaged as gems, for more information on packaging your
+linters as gems see this [example](https://github.com/cih/scss_lint_plugin_example).
+If the gem is packaged with an `.scss-lint.yml` file this will be merged with your configuration
+and can be overriden in your `.scss-lint.yml`.
+
+```yaml
+  # .scss-lint.yml
+  plugin_gems: ['scss_lint_plugin_example']
+```
+
 ## Exit Status Codes
 
 `scss-lint` tries to use

--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ scss-lint --require=scss_lint_reporter_checkstyle --format=Checkstyle [scss-file
 
 #### Linters
 
-By default `scss-lint` will load linters from `.scss-linter-plugins` in the root of
+By default `scss-lint` will load linters from `.scss-linters` in the root of
 your repository. You can customise the loaded directories by setting `plugin_directories`
 in your `.scss-lint.yml` configuration file. Simply create your linter indentical in structure
 to the https://github.com/brigade/scss-lint/tree/master/lib/scss_lint/linter directory, they will be enabled by default but configuration can be overriden in your `.scss-lint.yml`.
 
 ```ruby
-# .scss-linter-plugins/another_linter.rb
+# .scss-linters/another_linter.rb
 
 module SCSSLint
   class Linter::AnotherLinter < Linter
@@ -316,7 +316,7 @@ end
 
 ```yaml
 # .scss-lint.yml
-plugin_directories: ['.scss-lint-plugins', '.another_directory', '/absolute/path']
+plugin_directories: ['.scss-linters', '.another_directory', '/absolute/path']
 
 linters:
   AnotherLinter:

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,7 +1,7 @@
 # Default application configuration that all configurations inherit from.
 
 scss_files: "**/*.scss"
-plugin_directories: ['.scss-lint-plugins']
+plugin_directories: ['.scss-linters']
 
 linters:
   BangFormat:

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,7 @@
 # Default application configuration that all configurations inherit from.
 
 scss_files: "**/*.scss"
+plugin_directories: ['.scss-lint-plugins']
 
 linters:
   BangFormat:

--- a/lib/scss_lint.rb
+++ b/lib/scss_lint.rb
@@ -11,6 +11,7 @@ require 'scss_lint/selector_visitor'
 require 'scss_lint/control_comment_processor'
 require 'scss_lint/version'
 require 'scss_lint/utils'
+require 'scss_lint/plugins'
 
 # Load Sass classes and then monkey patch them
 require 'sass'

--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -39,13 +39,16 @@ module SCSSLint
         print_help(options)
       elsif options[:version]
         print_version
-      elsif options[:show_linters]
-        print_linters
       elsif options[:show_formatters]
         print_formatters
       else
         config = setup_configuration(options)
-        scan_for_lints(options, config)
+
+        if options[:show_linters]
+          print_linters
+        else
+          scan_for_lints(options, config)
+        end
       end
     end
 
@@ -107,6 +110,7 @@ module SCSSLint
     def setup_configuration(options)
       config_file = relevant_configuration_file(options)
       config = config_file ? Config.load(config_file) : Config.default
+      config.load_plugins
       merge_options_with_config(options, config)
     end
 

--- a/lib/scss_lint/exceptions.rb
+++ b/lib/scss_lint/exceptions.rb
@@ -18,4 +18,7 @@ module SCSSLint::Exceptions
 
   # Raised when a required library (specified via command line) does not exist.
   class RequiredLibraryMissingError < StandardError; end
+
+  # Raised when a linter gem plugin is required but not installed.
+  class PluginGemLoadError < StandardError; end
 end

--- a/lib/scss_lint/plugins.rb
+++ b/lib/scss_lint/plugins.rb
@@ -1,0 +1,35 @@
+require_relative 'plugins/linter_gem'
+require_relative 'plugins/linter_dir'
+
+module SCSSLint
+  # Loads plugin directories and gems
+  class Plugins
+    def initialize(config_options)
+      @config_options = config_options
+    end
+
+    def load
+      all.map(&:load)
+    end
+
+  private
+
+    attr_reader :config_options
+
+    def all
+      [plugin_gems, plugin_directories].flatten
+    end
+
+    def plugin_gems
+      config_options.fetch('plugin_gems', []).map do |gem_name|
+        LinterGem.new(gem_name)
+      end
+    end
+
+    def plugin_directories
+      config_options.fetch('plugin_directories', []).map do |directory|
+        LinterDir.new(directory)
+      end
+    end
+  end
+end

--- a/lib/scss_lint/plugins/linter_dir.rb
+++ b/lib/scss_lint/plugins/linter_dir.rb
@@ -1,0 +1,26 @@
+module SCSSLint
+  class Plugins
+    # Load ruby files from linter plugin directories
+    class LinterDir
+      attr_reader :config_options
+
+      def initialize(dir)
+        @dir = dir
+        @config_options = {}
+      end
+
+      def load
+        ruby_files.each { |file| require file }
+        self
+      end
+
+    private
+
+      attr_reader :dir
+
+      def ruby_files
+        Dir.glob(File.expand_path(File.join(dir, '/**/*.rb')))
+      end
+    end
+  end
+end

--- a/lib/scss_lint/plugins/linter_gem.rb
+++ b/lib/scss_lint/plugins/linter_gem.rb
@@ -1,0 +1,55 @@
+module SCSSLint
+  class Plugins
+    # Load linter plugin gems
+    class LinterGem
+      def initialize(name)
+        @name = name
+      end
+
+      def load
+        require name
+        self
+      rescue LoadError
+        raise_error
+      end
+
+      def config_options
+        if File.exist?(config_file)
+          load_config_from_file(config_file)
+        else
+          {}
+        end
+      end
+
+    private
+
+      attr_reader :name
+
+      def load_config_from_file(config_file)
+        Config.send(:load_options_hash_from_file, config_file)
+      end
+
+      def config_file
+        File.join(gem_dir, Config::FILE_NAME)
+      end
+
+      def gem_specification
+        Gem::Specification.find_by_name(name)
+      rescue Gem::LoadError
+        raise_error
+      end
+
+      def gem_dir
+        gem_specification.gem_dir
+      end
+
+      def raise_error
+        raise SCSSLint::Exceptions::PluginGemLoadError,
+              "Unable to load linter plugin gem '#{name}' as it's not " \
+              'part of the bundle, linter_plugin_gems are specified in ' \
+              "your scss_lint.yml configuration. Try running 'gem install " \
+              "#{name}'"
+      end
+    end
+  end
+end

--- a/spec/scss_lint/config_spec.rb
+++ b/spec/scss_lint/config_spec.rb
@@ -250,4 +250,30 @@ describe SCSSLint::Config do
       end
     end
   end
+
+  describe '#load_plugins' do
+    let(:config) { described_class.new(options) }
+    let(:subject) { config.load_plugins }
+
+    let(:linter_options) do
+      {
+        'enabled' => true,
+      }
+    end
+
+    let(:options) do
+      {
+        'linters' => {
+          'FakeConfigLinter' => linter_options
+        }
+      }
+    end
+
+    context 'no plugins' do
+      it 'will return an empty Array' do
+        expect(subject).to be_instance_of Array
+        expect(subject).to be_empty
+      end
+    end
+  end
 end

--- a/spec/scss_lint/fixtures/plugins/linter_plugin.rb
+++ b/spec/scss_lint/fixtures/plugins/linter_plugin.rb
@@ -1,0 +1,7 @@
+module SCSSLint
+  class Linter
+    class LinterPlugin < Linter
+      include LinterRegistry
+    end
+  end
+end

--- a/spec/scss_lint/plugins/linter_dir_spec.rb
+++ b/spec/scss_lint/plugins/linter_dir_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe SCSSLint::Plugins::LinterDir do
+  let(:plugin_directory) { File.expand_path('../../fixtures/plugins', __FILE__) }
+  let(:subject) { described_class.new(plugin_directory) }
+
+  describe '#config_options' do
+    it 'will return a Hash' do
+      expect(subject.config_options).to be_instance_of Hash
+    end
+
+    it 'will be empty' do
+      expect(subject.config_options.empty?).to be true
+    end
+  end
+
+  describe '#load' do
+    it 'will require each file in the dir' do
+      subject.should_receive(:require)
+        .with(File.join(plugin_directory, 'linter_plugin.rb')).once
+
+      subject.load
+    end
+  end
+end

--- a/spec/scss_lint/plugins/linter_gem_spec.rb
+++ b/spec/scss_lint/plugins/linter_gem_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+module SCSSLint
+  describe Plugins::LinterGem do
+    let(:subject) { described_class.new('a_gem') }
+
+    describe '#load' do
+      it 'will raise an exception if the gem is not installed' do
+        expect do
+          subject.load
+        end.to raise_exception Exceptions::PluginGemLoadError
+      end
+
+      it 'will require the gem' do
+        subject.should_receive(:require).with('a_gem').once
+        subject.load
+      end
+    end
+
+    describe '#config_options' do
+      it 'will raise an exception if the gem is not installed' do
+        expect do
+          subject.config_options
+        end.to raise_exception Exceptions::PluginGemLoadError
+      end
+
+      context 'gem loaded' do
+        before do
+          described_class.any_instance.stub(:require).and_return true
+          subject.stub(:gem_dir).and_return '/dir'
+        end
+
+        context 'with config file' do
+          it 'will load the config' do
+            File.stub(:exist?).and_return true
+            subject.should_receive(:load_config_from_file)
+                  .with('/dir/.scss-lint.yml').and_return({})
+
+            subject.config_options
+          end
+        end
+
+        context 'no config file' do
+          it 'will return an empty hash' do
+            expect(subject.config_options).to be_a Hash
+            expect(subject.config_options.empty?).to be true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scss_lint/plugins_spec.rb
+++ b/spec/scss_lint/plugins_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+module SCSSLint
+  describe Plugins do
+    describe 'from_config_options' do
+      let(:subject) { described_class.new(config_options) }
+
+      describe 'load' do
+        context 'with plugins' do
+          let(:config_options) do
+            { 'plugin_directories' => ['a_dir'],
+              'plugin_gems' => ['a_gem'] }
+          end
+
+          context 'required successfully' do
+            before do
+              Plugins::LinterGem.any_instance.stub(:require).and_return true
+              Plugins::LinterDir.any_instance.stub(:require).and_return true
+            end
+
+            it 'will return an Array' do
+              expect(subject.load).to be_instance_of Array
+            end
+
+            it 'will contain 2 items' do
+              expect(subject.load.count).to eq 2
+            end
+          end
+
+          it 'will raise an exception if the gem is not required' do
+            expect do
+              subject.load
+            end.to raise_exception Exceptions::PluginGemLoadError
+          end
+        end
+
+        context 'without plugins' do
+          let(:config_options) do
+            { 'plugin_directories' => [],
+              'plugin_gems' => [] }
+          end
+
+          it 'will return an Array' do
+            expect(subject.load).to be_instance_of Array
+          end
+
+          it 'will be empty' do
+            expect(subject.load.empty?).to be true
+          end
+        end
+
+        context 'without config' do
+          let(:config_options) { Hash.new }
+
+          it 'will return an Array' do
+            expect(subject.load).to be_instance_of Array
+          end
+
+          it 'will be empty' do
+            expect(subject.load.empty?).to be true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey Guys,

I noticed you had a couple of open issues that mentioned the need for supporting custom linters https://github.com/brigade/scss-lint/issues/161 and https://github.com/brigade/scss-lint/issues/440. I'm not sure exactly what you had in mind but I've had a go at implementing this to allow plugin directories and plugin gems. Used a couple of private methods as I didn't want to move stuff around too much without being familiar with the codebase, let me know what you think, hope this helps.