### PR TITLE
Fix sort order link in linter docs

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -810,7 +810,7 @@ execute `:sort` in `vim`), and it can
 You can also specify an explicit ordering via the `order` option, which allows
 you to specify an explicit array of properties representing the preferred
 order, or the name of a
-[preset order](data/property-sort-orders).
+[preset order](../../../../master/data/property-sort-orders).
 If a property is not in your explicit list, it will be placed at the bottom of
 the list, disregarding its order relative to other unspecified properties.
 


### PR DESCRIPTION
Link in linter docs appears to be from the times when linter readme was part of main project readme. Not a fan of absolute path, but it's better than a 404.
![](http://33.media.tumblr.com/e7cfe0074ae5fd4bd2f47735e9f53206/tumblr_mkwpqrtiJN1rsdpaso1_500.gif)