### PR TITLE
add a few properties to smacss property order preset

### DIFF
--- a/data/property-sort-orders/smacss.txt
+++ b/data/property-sort-orders/smacss.txt
@@ -30,6 +30,8 @@ padding-right
 padding-bottom
 padding-left
 
+box-sizing
+
 float
 clear
 
@@ -43,6 +45,7 @@ column-width
 
 transform
 transition
+animation
 
 # Border
 
@@ -102,9 +105,10 @@ font-style
 font-variant
 font-weight
 
-letter-spacing
 line-height
 list-style
+list-style-type
+list-style-image
 
 text-align
 text-decoration
@@ -113,9 +117,12 @@ text-overflow
 text-rendering
 text-shadow
 text-transform
-text-wrap
 
 white-space
+word-wrap
+word-break
+
+letter-spacing
 word-spacing
 
 # Other


### PR DESCRIPTION
Smacss book seems to have just a general idea about property order, and I feel this one you have as a preset could have a couple more properties.

Added `box-sizing`, `animation`, `list-style-type` and `list-style-image`, `word-wrap` and `word-break`.

Grouped `letter-spacing` and `word-spacing` together. 

Removed `text-wrap` as it appears to be [deprecated](http://www.w3schools.com/cssref/css3_pr_text-wrap.asp).

No urgency, not a huge deal really as setting `ignore_unspecified: true` helps with most of these - but hey, might as well suggest improving the predefined config.