### PR TITLE
Add option to ignore parent selectors in NestingDepth linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   by the `SelectorFormat` linter
 * Add `TrailingWhitespace` linter which reports whitespace characters at the
   end of a line
+* Change `NestingDepth` to allow parent selectors to be ignored in depth count
+  by passing configuration option `ignore_parent_selectors: true`
 
 ## 0.39.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -101,6 +101,7 @@ linters:
   NestingDepth:
     enabled: true
     max_depth: 3
+    ignore_parent_selectors: false
 
   PlaceholderInExtend:
     enabled: true

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -749,9 +749,10 @@ of applicability](http://smacss.com/book/applicability). Use
 }
 ```
 
-Configuration Option | Description
----------------------|---------------------------------------------------------
-`max_depth`          | Maximum depth before reporting errors (default **3**)
+Configuration Option        | Description
+----------------------------|---------------------------------------------------------
+`max_depth`                 | Maximum depth before reporting errors (default **3**)
+`ignore_parent_selectors`   | Whether to report errors for parent selectors (default **false**)
 
 ## PlaceholderInExtend
 

--- a/spec/scss_lint/linter/nesting_depth_spec.rb
+++ b/spec/scss_lint/linter/nesting_depth_spec.rb
@@ -111,4 +111,76 @@ describe SCSSLint::Linter::NestingDepth do
       it { should_not report_lint }
     end
   end
+
+  context 'nesting parent selectors' do
+    let(:scss) { <<-SCSS }
+      .one {
+        .two {
+          .three {
+            &:hover,
+            &-suffix {
+              .five {
+                background: #f00;
+              }
+            }
+          }
+
+          .another-three { }
+        }
+      }
+    SCSS
+
+    context 'when parent selectors are ignored' do
+      let(:default_linter_config) { { 'ignore_parent_selectors' => true } }
+
+      context 'and max depth is set to 2' do
+        let(:linter_config) { default_linter_config.merge('max_depth' => 2) }
+
+        it { should report_lint line: 3 }
+        it { should report_lint line: 12 }
+        it { should_not report_lint line: 4 }
+        it { should_not report_lint line: 6 }
+      end
+
+      context 'and max depth is set to 3' do
+        let(:linter_config) { default_linter_config.merge('max_depth' => 3) }
+
+        it { should_not report_lint line: 4 }
+        it { should_not report_lint line: 5 }
+        it { should report_lint line: 6 }
+      end
+
+      context 'and max depth is set to 4' do
+        let(:linter_config) { default_linter_config.merge('max_depth' => 4) }
+
+        it { should_not report_lint }
+      end
+    end
+
+    context 'when not ignoring parent selectors' do
+      let(:default_linter_config) { { 'ignore_parent_selectors' => false } }
+
+      context 'and max depth is set to 2' do
+        let(:linter_config) { default_linter_config.merge('max_depth' => 2) }
+
+        it { should report_lint line: 3 }
+        it { should report_lint line: 12 }
+        it { should_not report_lint line: 4 }
+        it { should_not report_lint line: 6 }
+      end
+
+      context 'and max depth is set to 3' do
+        let(:linter_config) { default_linter_config.merge('max_depth' => 3) }
+
+        it { should report_lint line: 4 }
+        it { should_not report_lint line: 12 }
+      end
+
+      context 'and max depth is set to 4' do
+        let(:linter_config) { default_linter_config.merge('max_depth' => 4) }
+
+        it { should report_lint line: 6 }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hey @sds,

I've added the option to `ignore_parent_selectors` based on these issues #384, #477 and #476. Hopefully this covers all the necessary cases, would you mind taking a look and let me know if I've missed anything?
