### PR TITLE
Control comment fixes

### DIFF
--- a/lib/scss_lint/control_comment_processor.rb
+++ b/lib/scss_lint/control_comment_processor.rb
@@ -82,10 +82,21 @@ module SCSSLint
       return unless comment_node = @disable_stack.pop
 
       start_line = comment_node.line
+      if comment_node.class.node_name == :rule
+        end_line = start_line
+      elsif node.class.node_name == :root
+        end_line = @linter.engine.lines.length
+      else
+        end_line = end_line(node)
+      end
 
-      # Find the deepest child that has a line number to which a lint might
-      # apply (if it is a control comment enable node, it will be the line of
-      # the comment itself).
+      @disabled_lines.merge(start_line..end_line)
+    end
+
+    # Find the deepest child that has a line number to which a lint might
+    # apply (if it is a control comment enable node, it will be the line of
+    # the comment itself).
+    def end_line(node)
       child = node
       prev_child = node
       until [nil, prev_child].include?(child = last_child(child))
@@ -94,9 +105,7 @@ module SCSSLint
 
       # Fall back to prev_child if last_child() returned nil (i.e. node had no
       # children with line numbers)
-      end_line = (child || prev_child).line
-
-      @disabled_lines.merge(start_line..end_line)
+      (child || prev_child).line
     end
 
     # Gets the child of the node that resides on the lowest line in the file.

--- a/lib/scss_lint/linter/final_newline.rb
+++ b/lib/scss_lint/linter/final_newline.rb
@@ -15,6 +15,7 @@ module SCSSLint
         add_lint(engine.lines.count,
                  'Files should not end with a trailing newline') if ends_with_newline
       end
+      yield
     end
   end
 end

--- a/lib/scss_lint/linter/space_between_parens.rb
+++ b/lib/scss_lint/linter/space_between_parens.rb
@@ -18,6 +18,7 @@ module SCSSLint
           check(match[2], index) if match[2]
         end
       end
+      yield
     end
 
   private

--- a/lib/scss_lint/linter/trailing_whitespace.rb
+++ b/lib/scss_lint/linter/trailing_whitespace.rb
@@ -9,6 +9,7 @@ module SCSSLint
 
         add_lint(index + 1, 'Line contains trailing whitespace')
       end
+      yield
     end
   end
 end

--- a/spec/scss_lint/linter_spec.rb
+++ b/spec/scss_lint/linter_spec.rb
@@ -7,6 +7,11 @@ describe SCSSLint::Linter do
 
     module SCSSLint
       class Linter::Fake < SCSSLint::Linter
+        def visit_root(node)
+          add_lint(engine.lines.count, 'final new line') unless engine.lines[-1][-1] == "\n"
+          yield
+        end
+
         def visit_prop(node)
           return unless node.value.to_sass.strip == 'fail1'
           add_lint(node, 'everything offends me')
@@ -47,7 +52,7 @@ describe SCSSLint::Linter do
     end
 
     context 'when a disable is present at the top level' do
-      let(:scss) { <<-SCSS }
+      let(:scss) { <<-SCSS.strip }
         // scss-lint:disable Fake
         p {
           border: fail1;
@@ -271,6 +276,10 @@ describe SCSSLint::Linter do
         .good-selector {
           border: fail1;
         }
+
+        p {
+          color: #FFF;
+        }
       SCSS
 
       it { should_not report_lint line: 1 }
@@ -279,6 +288,10 @@ describe SCSSLint::Linter do
 
     context 'when /* control comment appears in the middle of a comma sequence' do
       let(:scss) { <<-SCSS }
+        p {
+          color: #FFF;
+        }
+
         .badClass, /* scss-lint:disable Fake */
         .good-selector {
           border: fail1;
@@ -286,7 +299,7 @@ describe SCSSLint::Linter do
       SCSS
 
       it { should_not report_lint line: 1 }
-      it { should report_lint line: 3 }
+      it { should report_lint line: 7 }
     end
   end
 end


### PR DESCRIPTION
Several fixes for control comment functionality

1: When control comment appears in the middle of a comma sequence
This was introduced by 1d892e2a. Looks like the tests are false positive because the rule is the only child of the root node. The following should raise a lint error but doesn't:
```
.a, // scss-lint:disable LeadingZero
.b {
  width: 0.5px;  
}
.another {
  color: #FFF;
}
```

2: `FinalNewline`, `SpaceBetweenParens`, and `TrailingWhitespace` linters add the lint errors in the `visit_root` method but it doesn't `yield` for the other nodes to be visited. That means any top level comment to disable all will not work. The following still raises lint errors:
```
// scss-lint:disable all
.another {
  color: rgba( 0, 0, 0, .1 );
}
```

3: Finally, for `FinalNewline` and `TrailingWhitespace`, you can get lint errors if your last line is the trailing `}`. The following will raise lint errors when it shouldn't:
```
// scss-lint:disable all
.another:after {
  content: 'There is no new final line and trailing spaces after the }'
}    
```