### PR TITLE
Add SpaceAfterVariableName linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   end of a line
 * Change `NestingDepth` to allow parent selectors to be ignored in depth count
   via the `ignore_parent_selectors` configuration option
+* Add `SpaceAfterVariableName` linter which checks that there are no spaces
+  between a variable name and a colon
 
 ## 0.39.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -169,6 +169,9 @@ linters:
   SpaceAfterPropertyName:
     enabled: true
 
+  SpaceAfterVariableName:
+    enabled: true
+
   SpaceBeforeBrace:
     enabled: true
     style: space # or 'new_line'

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -42,6 +42,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [SpaceAfterComma](#spaceaftercomma)
 * [SpaceAfterPropertyColon](#spaceafterpropertycolon)
 * [SpaceAfterPropertyName](#spaceafterpropertyname)
+* [SpaceAfterVariableName](#spaceaftervariablename)
 * [SpaceBeforeBrace](#spacebeforebrace)
 * [SpaceBetweenParens](#spacebetweenparens)
 * [StringQuotes](#stringquotes)
@@ -1243,6 +1244,20 @@ margin : 0;
 **Good**
 ```scss
 margin: 0;
+```
+
+## SpaceAfterVariableName
+
+Variables should be formatted with no space between the name and the colon.
+
+**Bad: space before colon**
+```scss
+$my-var : 0;
+```
+
+**Good**
+```scss
+$my-var: 0;
 ```
 
 ## SpaceBeforeBrace

--- a/lib/scss_lint/linter/space_after_variable_name.rb
+++ b/lib/scss_lint/linter/space_after_variable_name.rb
@@ -1,0 +1,18 @@
+module SCSSLint
+  # Checks for spaces following the name of a variable and before the colon
+  # separating the variables's name from its value.
+  class SpaceAfterVariableName < Linter
+    include LinterRegistry
+
+    def visit_variable(node)
+      return unless spaces_before_colon?(node)
+      add_lint(node, 'Variable names should be followed immediately by a colon')
+    end
+
+  private
+
+    def spaces_before_colon?(node)
+      source_from_range(node.source_range) =~ /\s+:/
+    end
+  end
+end

--- a/spec/scss_lint/linter/space_after_variable_name_spec.rb
+++ b/spec/scss_lint/linter/space_after_variable_name_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe SCSSLint::SpaceAfterVariableName do
+  let(:scss) { <<-SCSS }
+    $none: #fff;
+    $one : #fff;
+    $two  : #fff;
+   SCSS
+
+  it { should_not report_lint line: 1 }
+  it { should report_lint line: 2 }
+  it { should report_lint line: 3 }
+end


### PR DESCRIPTION
This adds a `SpaceAfterVariableName` linter as mentioned in #445, I should be able to send up another PR soon to add the `SpaceAfterVariableColon` linter too, hope this helps!