### PR TITLE
Reorder config to be alphabetical & match documentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -111,6 +111,16 @@ linters:
     include_nested: false
     max_properties: 10
 
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+    
   PropertyUnits:
     enabled: true
     global: [
@@ -123,16 +133,6 @@ linters:
       'dpi', 'dpcm', 'dppx',                   # Resolution
       '%']                                     # Other
     properties: {}
-
-  PropertySortOrder:
-    enabled: true
-    ignore_unspecified: false
-    min_properties: 2
-    separate_groups: false
-
-  PropertySpelling:
-    enabled: true
-    extra_properties: []
 
   QualifyingElement:
     enabled: true


### PR DESCRIPTION
- easier to follow along if default config and documentation are in the same order