### PR TITLE
New linter: SpaceAroundOperator

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -169,6 +169,10 @@ linters:
   SpaceAfterPropertyName:
     enabled: true
 
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space # or 'no_space'
+
   SpaceBeforeBrace:
     enabled: true
     style: space # or 'new_line'

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -43,6 +43,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [SpaceAfterPropertyColon](#spaceafterpropertycolon)
 * [SpaceAfterPropertyName](#spaceafterpropertyname)
 * [SpaceAfterVariableName](#spaceaftervariablename)
+* [SpaceAroundOperator](#spacearoundoperator)
 * [SpaceBeforeBrace](#spacebeforebrace)
 * [SpaceBetweenParens](#spacebetweenparens)
 * [StringQuotes](#stringquotes)

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -1245,6 +1245,37 @@ margin : 0;
 margin: 0;
 ```
 
+## SpaceAroundOperator
+
+Operators should be formatted with a single space on both sides of an infix
+operator. These include `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `>`, `>=`, `<`,
+and `<=`.
+
+**Bad: no space around operator**
+```scss
+margin: 5px+5px;
+```
+
+**Bad: more than one space around operator**
+```scss
+margin: 5px   +   5px;
+```
+
+**Good**
+```scss
+margin: 5px + 5px;
+```
+
+Note that this linter only applies to actual, evaluated operators. So values
+like `nth-child(2n+1)`, `10px/12px`, and `my-font` will not be linted, as they
+are valid CSS.
+
+The `style` option allows you to specify a different preferred style.
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`style`              | `one_space`, `no_space` (default **one_space**)
+
 ## SpaceBeforeBrace
 
 Opening braces should be preceded by a single space.

--- a/lib/scss_lint/linter/space_around_operator.rb
+++ b/lib/scss_lint/linter/space_around_operator.rb
@@ -1,0 +1,66 @@
+module SCSSLint
+  # Checks for space around operators on values.
+  class Linter::SpaceAroundOperator < Linter
+    include LinterRegistry
+
+    def visit_script_operation(node)
+      source = source_from_range(node.source_range)
+
+      all_matches(source) do |match|
+        if config['style'] == 'one_space'
+          if match[:lspace] != ' ' || match[:rspace] != ' '
+            add_lint(node, space_message(match))
+          end
+        elsif match[:lspace] != '' || match[:rspace] != ''
+          add_lint(node, no_space_message(match))
+        end
+      end
+    end
+
+  private
+
+    OPERATOR_REGEX = /
+      \b
+      (?<operation>
+        (?<loperand>[^\s]+?)
+        (?<lspace>\s*)
+        (?<operator>
+          (?:==|!=|>|>=|<|<=) |  # Comparison operators
+          (?:[+\-*\/%])          # Mathematical operators
+        )
+        (?<rspace>\s*)
+        (?<roperand>[^\s]+)
+      )
+      \b
+    /ix
+
+    # Finds all matches of OPERATOR_REGEX in a String. This method differs from
+    # String#scan in that it will find intermediate matches that #scan
+    # inherently walks past. For example:
+    #
+    #     all_matches("1 + 2 + 3 + 4 + 5")      #=> ["1 + 2", "2 + 3", "3 + 4", "4 + 5"]
+    #     "1 + 2 + 3 + 4 + 5".scan(/\d \+ \d/)  #=> ["1 + 2", "3 + 4"]
+    def all_matches(string)
+      start = 0
+      finish = string.length
+
+      while start < finish
+        match = string[start..-1].match(OPERATOR_REGEX)
+        return if match.nil?
+
+        yield match
+        start += match.begin(:operator) + 1  # Move forward one character past the operator.
+      end
+    end
+
+    def space_message(match)
+      "`%s` should be written with a single space on each side of the operator: `%s %s %s`" %
+        [match[:operation], match[:loperand], match[:operator], match[:roperand]]
+    end
+
+    def no_space_message(match)
+      "`%s` should be written without spaces around the operator: `%s%s%s`" %
+        [match[:operation], match[:loperand], match[:operator], match[:roperand]]
+    end
+  end
+end

--- a/lib/scss_lint/linter/space_around_operator.rb
+++ b/lib/scss_lint/linter/space_around_operator.rb
@@ -16,11 +16,11 @@ module SCSSLint
       operator_source = source_between(left_range, right_range)
       left_source, operator_source = adjust_left_boundary(left_source, operator_source)
 
-      match = operator_source.match(%r{
+      match = operator_source.match(/
         (?<left_space>\s*)
         (?<operator>\S+)
         (?<right_space>\s*)
-      }x)
+      /x)
 
       if config['style'] == 'one_space'
         if match[:left_space] != ' ' || match[:right_space] != ' '
@@ -34,14 +34,15 @@ module SCSSLint
     end
 
   private
-    SPACE_MSG = "`%s` should be written with a single space on each side of the operator: `%s %s %s`"
-    NO_SPACE_MSG = "`%s` should be written without spaces around the operator: `%s%s%s`"
+
+    SPACE_MSG = '`%s` should be written with a single space on each side of the operator: `%s %s %s`'
+    NO_SPACE_MSG = '`%s` should be written without spaces around the operator: `%s%s%s`'
 
     def source_between(range1, range2)
       # We don't want to add 1 to range1.end_pos.offset for the same reason as
       # the #chop comment above.
       between_start = Sass::Source::Position.new(range1.end_pos.line, range1.end_pos.offset)
-      between_end = Sass::Source::Position.new(range2.start_pos.line, range2.start_pos.offset-1)
+      between_end = Sass::Source::Position.new(range2.start_pos.line, range2.start_pos.offset - 1)
 
       source_from_range Sass::Source::Range.new(between_start, between_end, range1.file, range1.importer)
     end
@@ -50,20 +51,20 @@ module SCSSLint
       # If the left operand is wrapped in parentheses, any right parens end up
       # in the operator source. Here, we move them into the left operand
       # source, which is awkward in any messaging, but it works.
-      if match = operator.match(%r{^(\s*\))+})
-        left = left + match[0]
+      if match = operator.match(/^(\s*\))+/)
+        left += match[0]
         operator = operator[match.end(0)..-1]
       end
 
       # If the left operand is a nested operation, Sass includes any whitespace
       # before the (outer) operator in the left operator's source_range's
       # end_pos, which is not the case with simple, non-operation operands.
-      if match = left.match(%r{\s+$})
+      if match = left.match(/\s+$/)
         left = left[0..match.begin(0)]
         operator = match[0] + operator
       end
 
-      return left, operator
+      [left, operator]
     end
   end
 end

--- a/lib/scss_lint/linter/space_around_operator.rb
+++ b/lib/scss_lint/linter/space_around_operator.rb
@@ -14,6 +14,7 @@ module SCSSLint
       left_source = source_from_range(left_range).chop
       right_source = source_from_range(right_range)
       operator_source = source_between(left_range, right_range)
+      left_source, operator_source = shift_parens(left_source, operator_source)
 
       match = operator_source.match(%r{
         (?<left_space>\s*)
@@ -37,12 +38,20 @@ module SCSSLint
     NO_SPACE_MSG = "`%s` should be written without spaces around the operator: `%s%s%s`"
 
     def source_between(range1, range2)
-      # We don't want to add 1 to range1.end_pos.offset because of the same
-      # reason as the #chop comment above.
+      # We don't want to add 1 to range1.end_pos.offset for the same reason as
+      # the #chop comment above.
       between_start = Sass::Source::Position.new(range1.end_pos.line, range1.end_pos.offset)
       between_end = Sass::Source::Position.new(range2.start_pos.line, range2.start_pos.offset-1)
 
       source_from_range Sass::Source::Range.new(between_start, between_end, range1.file, range1.importer)
+    end
+
+    # If the left operand is wrapped in parentheses, the right parens are _not_
+    # included in the left operand's source. We correct this here, shifting any
+    # right parens off the operator source, onto the left operand's source.
+    def shift_parens(left, operator)
+      match = operator.match %r{^(\s*\))*}
+      [left + match[0], operator[match.end(0)..-1]]
     end
   end
 end

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -157,9 +157,14 @@ describe SCSSLint::Linter::SpaceAroundOperator do
 
         p {
           font: 12px/10px;
-          margin: 2em-1em;
-          padding: $my-variable;
-          font-size: em(16px / $base-font-size);
+          // In Sass <= 3.4.15, these `-` are not parsed as operators. In
+          // Sass 3.4.16, this was fixed, so that they are parsed as operators.
+          // These examples are commented out for now, until scss-lint requires
+          // Sass >= 3.4.16.
+          // margin: 2em-1em;
+          // padding: $my-variable;
+          // font-size: em(16px / $base-font-size);
+          font-size: 20px;
         }
       SCSS
 

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -166,7 +166,7 @@ describe SCSSLint::Linter::SpaceAroundOperator do
       it { should_not report_lint }
     end
 
-    context 'when values with parens and padded operations exist' do
+    context 'when values with nested operators and proper space exist' do
       let(:scss) { <<-SCSS }
         p {
           top: ($number) * -2;
@@ -174,6 +174,16 @@ describe SCSSLint::Linter::SpaceAroundOperator do
           top: (($number  )  ) * ( ( 2 ) );
           top: ($number
                    ) * ( 2 );
+          top: 2px + 3px + 4px;
+          top: (2px + 3px) + 4px;
+          top: (  2px + 3px  ) + 4px;
+          top: 2px + (3px + 4px);
+          top: 2px + (  3px + 4px  );
+          top: (2px) + (3px) + (4px);
+          top: (  2px  ) + (  3px  ) + (  4px  );
+        }
+
+        @if $var == 1 or $var == 2 {
         }
       SCSS
 

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -139,9 +139,12 @@ describe SCSSLint::Linter::SpaceAroundOperator do
 
     context 'when values with non-evaluated operations exist' do
       let(:scss) { <<-SCSS }
+        $my-variable: 10px;
+
         p {
           font: 12px/10px;
           margin: 2em-1em;
+          padding: $my-variable;
         }
       SCSS
 

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -60,6 +60,20 @@ describe SCSSLint::Linter::SpaceAroundOperator do
       it { should report_lint line: 10 }
     end
 
+    context 'when numeric values with infix operators and newlines exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 7px+
+              7px;
+          padding: 9px
+              + 9px;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+      it { should report_lint line: 4 }
+    end
+
     context 'when numeric values with multiple infix operators exist' do
       let(:scss) { <<-SCSS }
         p {
@@ -145,6 +159,7 @@ describe SCSSLint::Linter::SpaceAroundOperator do
           font: 12px/10px;
           margin: 2em-1em;
           padding: $my-variable;
+          font-size: em(16px / $base-font-size);
         }
       SCSS
 

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -1,0 +1,198 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::SpaceAroundOperator do
+  let(:linter_config) { { 'style' => style } }
+
+  context 'when one space is preferred' do
+    let(:style) { 'one_space' }
+
+    context 'when no properties exist' do
+      let(:scss) { <<-SCSS }
+        p {
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when values without infix operators exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 5px;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when values with properly-spaced infix operators exist' do
+      let(:scss) { <<-SCSS }
+        $x: 2px + 2px;
+
+        p {
+          margin: 5px + 5px;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when numeric values with infix operators exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 5px+5px;
+          margin: 5px  +  5px;
+          margin: 4px*2;
+          margin: 20px%3;
+          font-family: sans-+serif;
+        }
+
+        $x: 10px+10px;
+        $x: 20px-10px;
+      SCSS
+
+      it { should report_lint line: 2 }
+      it { should report_lint line: 3 }
+      it { should report_lint line: 4 }
+      it { should report_lint line: 5 }
+      it { should report_lint line: 6 }
+      it { should report_lint line: 9 }
+      it { should report_lint line: 10 }
+    end
+
+    context 'when numeric values with multiple infix operators exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 5px*2+8px;
+        }
+      SCSS
+
+      it { should report_lint line: 2, count: 2 }
+    end
+
+    context 'when if nodes with comparison infix operators exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          @if 3==2 {
+            margin: 5px;
+          }
+
+          @if 5>4 {
+            margin: 5px;
+          }
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+      it { should report_lint line: 6 }
+    end
+
+    context 'when values containing multiple operators exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 2px+8px 18px+12px;
+        }
+      SCSS
+
+      it { should report_lint line: 2, count: 2 }
+    end
+
+    context 'when a function call contains a value with infix operators' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: some-function(2em+1em);
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when mixin include contains a value with infix operators' do
+      let(:scss) { <<-SCSS }
+        p {
+          @include some-mixin(4em-2em);
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when string contains an infix operator' do
+      let(:scss) { <<-SCSS }
+        p {
+          content: func("4em-2em");
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when string contains an interpolated infix operator' do
+      let(:scss) { <<-SCSS }
+        p {
+          content: "There are \#{11+1} months."
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when values with non-evaluated operations exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          font: 12px/10px;
+          margin: 2em-1em;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when values with proper division operations exist' do
+      let(:scss) { <<-SCSS }
+        $x: 20px;
+        p {
+          width: $x/2;
+          width: round(1.5)/2;
+          width: (50px/2);
+          width: 10px + 20px/2;
+        }
+      SCSS
+
+      it { should report_lint line: 3 }
+      it { should report_lint line: 4 }
+      it { should report_lint line: 5 }
+      it { should report_lint line: 6 }
+    end
+  end
+  context 'when one space is preferred' do
+    let(:style) { 'no_space' }
+
+    context 'when values with single-spaced infix operators exist' do
+      let(:scss) { <<-SCSS }
+        $x: 2px + 2px;
+
+        p {
+          margin: 5px + 5px;
+          width: 5px   +       5px;
+        }
+      SCSS
+
+      it { should report_lint line: 1 }
+      it { should report_lint line: 4 }
+      it { should report_lint line: 5 }
+    end
+
+    context 'when values with no-spaced infix operators exist' do
+      let(:scss) { <<-SCSS }
+        $x: 2px+2px;
+
+        p {
+          margin: 5px+5px;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+end

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -166,6 +166,20 @@ describe SCSSLint::Linter::SpaceAroundOperator do
       it { should_not report_lint }
     end
 
+    context 'when values with parens and padded operations exist' do
+      let(:scss) { <<-SCSS }
+        p {
+          top: ($number) * -2;
+          top: (($number)) * ((2));
+          top: (($number  )  ) * ( ( 2 ) );
+          top: ($number
+                   ) * ( 2 );
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
     context 'when values with proper division operations exist' do
       let(:scss) { <<-SCSS }
         $x: 20px;


### PR DESCRIPTION
Fixes #400 

Essentially explained in the README change, and in [my comment on #400](https://github.com/brigade/scss-lint/issues/400#issuecomment-116768105).

I think that `#all_matches` is a weak spot in this PR: it's not well unit-tested. However, it's not general purpose enough to go into `lib/scss-lint/utils.rb` (which also doesn't have it's own unit tests), and the specs revealed a few bugs that I fixed along the way. If this method should be implemented in some other way, I'm open.