### PR TITLE
New linter: DisableLinterReason

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -36,6 +36,9 @@ linters:
   DeclarationOrder:
     enabled: true
 
+  DisableLinterReason:
+    enabled: false
+
   DuplicateProperty:
     enabled: true
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -11,6 +11,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [Compass Linters](#compass-linters)
 * [DebugStatement](#debugstatement)
 * [DeclarationOrder](#declarationorder)
+* [DisableLinterReason](#disablelinterreason)
 * [DuplicateProperty](#duplicateproperty)
 * [ElsePlacement](#elseplacement)
 * [EmptyLineBetweenBlocks](#emptylinebetweenblocks)
@@ -253,6 +254,28 @@ the cascade or nested rule sets, which justifies their inclusion *after*
 regular properties.
 
 Mixin `@content` and nested rule sets are also linted for declaration order.
+
+## DisableLinterReason
+
+`scss-lint:disable` control comments should be preceded by a comment explaining
+why these linters are being disabled for this file.
+
+**Bad**
+```scss
+// scss-lint:disable BorderZero
+p {
+  border: none;
+}
+```
+
+**Good**
+```scss
+// We really prefer `border: none` in this file, for reasons.
+// scss-lint:disable BorderZero
+p {
+  border: none;
+}
+```
 
 ## DuplicateProperty
 

--- a/lib/scss_lint/linter/disable_linter_reason.rb
+++ b/lib/scss_lint/linter/disable_linter_reason.rb
@@ -4,9 +4,9 @@ module SCSSLint
     include LinterRegistry
 
     def visit_comment(node)
-      return unless node.value.first.match(COMMAND_REGEX)
-
-      # No lint if the first line of the comment is not the command.
+      # No lint if the first line of the comment is not a command (because then
+      # either this comment has no commands, or the first line serves as a the
+      # reason for a command on a later line).
       return unless comment_lines(node).first.match(COMMAND_REGEX)
 
       # Maybe the previous node is the "reason" comment.

--- a/lib/scss_lint/linter/disable_linter_reason.rb
+++ b/lib/scss_lint/linter/disable_linter_reason.rb
@@ -27,7 +27,7 @@ module SCSSLint
     COMMAND_REGEX = %r{
       (/|\*)\s* # Comment start marker
       scss-lint:
-      (?<action>disable|enable)\s+
+      (?<action>disable)\s+
       (?<linters>.*?)
       \s*(?:\*/|\n) # Comment end marker or end of line
     }x

--- a/lib/scss_lint/linter/disable_linter_reason.rb
+++ b/lib/scss_lint/linter/disable_linter_reason.rb
@@ -1,0 +1,39 @@
+module SCSSLint
+  # Checks for "reason" comments above linter-disabling comments.
+  class Linter::DisableLinterReason < Linter
+    include LinterRegistry
+
+    def visit_comment(node)
+      return unless node.value.first.match(COMMAND_REGEX)
+
+      # No lint if the first line of the comment is not the command.
+      return unless comment_lines(node).first.match(COMMAND_REGEX)
+
+      # Maybe the previous node is the "reason" comment.
+      prev = previous_node(node)
+
+      if prev && prev.is_a?(Sass::Tree::CommentNode)
+        # No lint if the last line of the previous comment is not a command.
+        return unless comment_lines(prev).last.match(COMMAND_REGEX)
+      end
+
+      add_lint(node,
+               'scss-lint:disable control comments should be preceded by a ' \
+               'comment explaining why the linters need to be disabled.')
+    end
+
+    private
+
+    COMMAND_REGEX = %r{
+      (/|\*)\s* # Comment start marker
+      scss-lint:
+      (?<action>disable|enable)\s+
+      (?<linters>.*?)
+      \s*(?:\*/|\n) # Comment end marker or end of line
+    }x
+
+    def comment_lines(node)
+      node.value.join.split("\n")
+    end
+  end
+end

--- a/spec/scss_lint/linter/disable_linter_reason_spec.rb
+++ b/spec/scss_lint/linter/disable_linter_reason_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::DisableLinterReason do
+  context 'when no disabling instructions exist' do
+    let(:scss) { <<-SCSS }
+      // Comment.
+      p {
+        margin: 0;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when no reason accompanies a disabling comment' do
+    let(:scss) { <<-SCSS }
+      // scss-lint:disable BorderZero
+      p {
+        margin: 0;
+      }
+    SCSS
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when a reason immediately precedes a disabling comment' do
+    let(:scss) { <<-SCSS }
+      // We like using `border: none` in our CSS.
+      // scss-lint:disable BorderZero
+      p {
+        margin: 0;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a reason precedes a disabling comment, at a distance' do
+    let(:scss) { <<-SCSS }
+      // We like using `border: none` in our CSS.
+
+      // scss-lint:disable BorderZero
+      p {
+        margin: 0;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Fixes #514. DisableLinterReason is explained over at #514 as well.

As for the implementation, a few notes:

* I chose to disable it by default, since it's not exactly standard, or obvious.
* I copied the `COMMAND_REGEX` from `control_comment_processor.rb`. There's probably a better way, but I dunno what y'all would prefer. Make `COMMAND_REGEX` a public constant in `control_comment_processor.rb`? Extract it out to `constants.rb`? `utils.rb`?