### PR TITLE
Bumping RSpec to 3.3

### DIFF
--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rainbow', '~> 2.0'
   s.add_dependency 'sass', '~> 3.4.1'
 
-  s.add_development_dependency 'rspec', '~> 3.1.0'
+  s.add_development_dependency 'rspec', '~> 3.3.0'
 end


### PR DESCRIPTION
I have a PR that I'm writing that would require RSpec 3.3 [1], so I'm requesting this bump.

RSpec 3.3 was released one month ago ([3.2 Release Notes](http://rspec.info/blog/2015/02/rspec-3-2-has-been-released/) and [3.3 Release Notes](http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/)). `bundle exec rspec` works out of the box for me in scss-lint with RSpec 3.3.0 and Ruby 2.0.0.

---

[1] I'm adding some tests for `report_lint` which would use `fail_with`, etc. from rspec-expectations. From the Release Notes:

>  "Add RSpec::Matchers::FailMatchers, a mixin which provides fail, fail_with and fail_including matchers for use in specifying that an expectation fails for use by extension/plugin authors. (Charlie Rudolph, #729)"