### PR TITLE
Fixing non-multiple match failure message, and tons of matcher tests

### DIFF
--- a/spec/scss_lint/linter/bang_format_spec.rb
+++ b/spec/scss_lint/linter/bang_format_spec.rb
@@ -105,7 +105,7 @@ describe SCSSLint::Linter::BangFormat do
     SCSS
 
     it 'does not loop forever' do
-      subject.should_not report_lint
+      should_not report_lint
     end
   end
 

--- a/spec/scss_lint/report_lint_spec.rb
+++ b/spec/scss_lint/report_lint_spec.rb
@@ -1,0 +1,260 @@
+require 'spec_helper'
+require 'rspec/matchers/fail_matchers'
+
+RSpec.configure do |config|
+  config.include RSpec::Matchers::FailMatchers
+end
+
+RSpec::Matchers.define_negated_matcher :succeed, :raise_error
+
+# In these tests, we cover all of the combinations of successful and failed
+# matches, expecting and _not_ expecting lints, specified and unspecified line
+# numbers, specified and unspecified lint counts, and singular and multiple
+# lints.
+describe 'report_lint' do
+  let(:subject) { SCSSLint::Linter::LeadingZero.new }
+
+  def run_with(scss)
+    subject.run(SCSSLint::Engine.new(code: scss), SCSSLint::Config.default.linter_options(subject))
+  end
+
+  context 'when expecting no lints' do
+    it 'matches zero expected lints' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should_not report_lint
+      }.to succeed
+    end
+
+    it 'fails to match one lint with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should_not report_lint
+      }.to fail_with 'expected that a lint would not be reported'
+    end
+  end
+
+  context 'when expecting no lints on a certain line' do
+    it 'matches zero expected lints' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should_not report_lint line: 1
+      }.to succeed
+    end
+
+    it 'matches zero expected lints on the specified line' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should_not report_lint line: 10
+      }.to succeed
+    end
+
+    it 'fails to match one lint on the specified line with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should_not report_lint line: 1
+      }.to fail_with 'expected that a lint would not be reported'
+    end
+  end
+
+  context 'when expecting a lint' do
+    it 'matches one expected lint' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint
+      }.to succeed
+    end
+
+    it 'matches multiple lints' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint
+      }.to succeed
+    end
+
+    it 'fails to match zero lints with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint
+      }.to fail_with 'expected that a lint would be reported'
+    end
+  end
+
+  context 'when expecting a lint on a certain line' do
+    it 'matches one expected lint' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 1
+      }.to succeed
+    end
+
+    it 'matches multiple lints' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint line: 1
+      }.to succeed
+    end
+
+    it 'fails to match zero lints with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint line: 1
+      }.to fail_with 'expected that a lint would be reported on line 1'
+    end
+
+    it 'fails to match lints on the wrong line with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 10
+      }.to fail_with 'expected that a lint would be reported on line 10, but one lint was reported on line 1'
+    end
+  end
+
+  context 'when expecting exactly one lint' do
+    it 'matches one expected lint' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint count: 1
+      }.to succeed
+    end
+
+    it 'fails to match zero lints with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint count: 1
+      }.to fail_with 'expected that exactly 1 lint would be reported'
+    end
+
+    it 'fails to match multiple lints with a meaningful message' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint count: 1
+      }.to fail_with 'expected that exactly 1 lint would be reported, but lints were reported on lines 1 and 1'
+    end
+
+    it 'fails to match lints on the wrong line with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 10, count: 1
+      }.to fail_with 'expected that exactly 1 lint would be reported on line 10, but one lint was reported on line 1'
+    end
+  end
+
+  context 'when expecting multiple lints' do
+    it 'matches multiple lints' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint count: 2
+      }.to succeed
+    end
+
+    it 'fails to match zero lints with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint count: 2
+      }.to fail_with 'expected that exactly 2 lints would be reported'
+    end
+
+    it 'fails to match one lint with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint count: 2
+      }.to fail_with 'expected that exactly 2 lints would be reported'
+    end
+
+    it 'fails to match lints on the wrong line with a meaningful message' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint line: 10, count: 2
+      }.to fail_with 'expected that exactly 2 lints would be reported on line 10, but lints were reported on lines 1 and 1'
+    end
+  end
+
+  context 'when expecting exactly one lint on a certain line' do
+    it 'matches one expected lint' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 1, count: 1
+      }.to succeed
+    end
+
+    it 'fails to match zero lints with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint line: 1, count: 1
+      }.to fail_with 'expected that exactly 1 lint would be reported on line 1'
+    end
+
+    it 'fails to match multiple lints with a meaningful message' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint line: 1, count: 1
+      }.to fail_with 'expected that exactly 1 lint would be reported on line 1, but lints were reported on lines 1 and 1'
+    end
+
+    it 'fails to match lints on the wrong line with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 10, count: 1
+      }.to fail_with 'expected that exactly 1 lint would be reported on line 10, but one lint was reported on line 1'
+    end
+  end
+
+  context 'when expecting multiple lints on a certain line' do
+    it 'matches one expected lint' do
+      run_with('p { margin: 0.5em 0.5em; }')
+
+      expect {
+        should report_lint line: 1, count: 2
+      }.to succeed
+    end
+
+    it 'fails to match zero lints with a meaningful message' do
+      run_with('p { margin: .5em; }')
+
+      expect {
+        should report_lint line: 1, count: 2
+      }.to fail_with 'expected that exactly 2 lints would be reported on line 1'
+    end
+
+    it 'fails to match one lint with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 1, count: 2
+      }.to fail_with 'expected that exactly 2 lints would be reported on line 1, but one lint was reported on line 1'
+    end
+
+    it 'fails to match lints on the wrong line with a meaningful message' do
+      run_with('p { margin: 0.5em; }')
+
+      expect {
+        should report_lint line: 10, count: 2
+      }.to fail_with 'expected that exactly 2 lints would be reported on line 10, but one lint was reported on line 1'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
     # If running a linter spec, run the described linter against the CSS code
     # for each example. This significantly DRYs up our linter specs to contain
     # only tests, since all the setup code is now centralized here.
-    if described_class <= SCSSLint::Linter
+    if described_class && described_class <= SCSSLint::Linter
       initial_indent = scss[/\A(\s*)/, 1]
       normalized_css = scss.gsub(/^#{initial_indent}/, '')
 

--- a/spec/support/matchers/report_lint.rb
+++ b/spec/support/matchers/report_lint.rb
@@ -8,13 +8,14 @@ RSpec::Matchers.define :report_lint do |options|
   end
 
   failure_message do |linter|
-    'expected that a lint would be reported' +
+    expected_count = count.nil? ? 'a lint' : count == 1 ? 'exactly 1 lint' : "exactly #{count} lints"
+    "expected that #{expected_count} would be reported" +
       (expected_line ? " on line #{expected_line}" : '') +
       case linter.lints.count
       when 0
         ''
       when 1
-        ", but was on line #{linter.lints.first.location.line}"
+        ", but one lint was reported on line #{linter.lints.first.location.line}"
       else
         lines = lint_lines(linter)
         ", but lints were reported on lines #{lines[0...-1].join(', ')} and #{lines.last}"


### PR DESCRIPTION
Fixes #524

When fixing #524, I thought that the message logic is complicated enough to warrant testing. So I wrote a crazy long test for `report_lint`.