### PR TITLE
Add a new CleanFilesReporter

### DIFF
--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -56,7 +56,7 @@ module SCSSLint
     def scan_for_lints(options, config)
       runner = Runner.new(config)
       runner.run(FileFinder.new(config).find(options[:files]))
-      report_lints(options, runner.lints)
+      report_lints(options, runner.lints, runner.files)
 
       if runner.lints.any?(&:error?)
         halt :error
@@ -159,10 +159,11 @@ module SCSSLint
 
     # @param options [Hash]
     # @param lints [Array<Lint>]
-    def report_lints(options, lints)
+    # @param files [Array<String>]
+    def report_lints(options, lints, files)
       sorted_lints = lints.sort_by { |l| [l.filename, l.location] }
       options.fetch(:reporters).each do |reporter, output|
-        results = reporter.new(sorted_lints).report_lints
+        results = reporter.new(sorted_lints, files).report_lints
         io = (output == :stdout ? $stdout : File.new(output, 'w+'))
         io.print results if results
       end

--- a/lib/scss_lint/reporter.rb
+++ b/lib/scss_lint/reporter.rb
@@ -1,14 +1,17 @@
 module SCSSLint
   # Responsible for displaying lints to the user in some format.
   class Reporter
-    attr_reader :lints
+    attr_reader :lints, :files
 
     def self.descendants
       ObjectSpace.each_object(Class).select { |klass| klass < self }
     end
 
-    def initialize(lints)
+    # @param lints [List<Lint>] a list of Lints sorted by file and line number
+    # @param files [List<String>] a list of the files that were linted
+    def initialize(lints, files)
       @lints = lints
+      @files = files
     end
 
     def report_lints

--- a/lib/scss_lint/reporter/clean_files_reporter.rb
+++ b/lib/scss_lint/reporter/clean_files_reporter.rb
@@ -1,0 +1,10 @@
+module SCSSLint
+  # Reports a single line for each clean file (having zero lints).
+  class Reporter::CleanFilesReporter < Reporter
+    def report_lints
+      dirty_files = lints.map(&:filename).uniq
+      clean_files = files - dirty_files
+      clean_files.sort.join("\n") + "\n" if clean_files.any?
+    end
+  end
+end

--- a/lib/scss_lint/runner.rb
+++ b/lib/scss_lint/runner.rb
@@ -2,7 +2,7 @@ module SCSSLint
   # Finds and aggregates all lints found by running the registered linters
   # against a set of SCSS files.
   class Runner
-    attr_reader :lints
+    attr_reader :lints, :files
 
     # @param config [Config]
     def initialize(config)
@@ -13,7 +13,8 @@ module SCSSLint
 
     # @param files [Array]
     def run(files)
-      files.each do |file|
+      @files = files
+      @files.each do |file|
         find_lints(file)
       end
     end

--- a/spec/scss_lint/reporter/clean_files_reporter_spec.rb
+++ b/spec/scss_lint/reporter/clean_files_reporter_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe SCSSLint::Reporter::CleanFilesReporter do
+  subject { described_class.new(lints, files) }
+
+  describe '#report_lints' do
+    context 'when there are no lints and no files' do
+      let(:files) { [] }
+      let(:lints) { [] }
+
+      it 'returns nil' do
+        subject.report_lints.should be_nil
+      end
+    end
+
+    context 'when there are no lints but some files were linted' do
+      let(:files) { %w{ c.scss b.scss a.scss } }
+      let(:lints) { [] }
+
+      it 'prints each file on its own line' do
+        subject.report_lints.count("\n").should == 3
+      end
+
+      it 'prints the files in order' do
+        subject.report_lints.split("\n")[0].should eq 'a.scss'
+        subject.report_lints.split("\n")[1].should eq 'b.scss'
+        subject.report_lints.split("\n")[2].should eq 'c.scss'
+      end
+
+      it 'prints a trailing newline' do
+        subject.report_lints[-1].should == "\n"
+      end
+    end
+
+    context 'when there are lints in some files' do
+      let(:dirty_files) { %w{ a.scss b.scss } }
+      let(:clean_files) { %w{ c.scss d.scss } }
+      let(:files) { dirty_files + clean_files }
+
+      let(:lints) do
+        dirty_files.map do |file|
+          SCSSLint::Lint.new(nil, file, SCSSLint::Location.new, '')
+        end
+      end
+
+      it 'prints the file for each lint' do
+        clean_files.each do |file|
+          subject.report_lints.scan(/#{file}/).count.should == 1
+        end
+      end
+
+      it 'does not print clean files' do
+        dirty_files.each do |file|
+          subject.report_lints.scan(/#{file}/).count.should == 0
+        end
+      end
+    end
+
+    context 'when there are lints in every file' do
+      let(:files) { %w{ a.scss b.scss c.scss d.scss } }
+
+      let(:lints) do
+        files.map do |file|
+          SCSSLint::Lint.new(nil, file, SCSSLint::Location.new, '')
+        end
+      end
+
+      it 'does not print clean files' do
+        subject.report_lints.should be_nil
+      end
+    end
+  end
+end

--- a/spec/scss_lint/reporter/config_reporter_spec.rb
+++ b/spec/scss_lint/reporter/config_reporter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe SCSSLint::Reporter::ConfigReporter do
   subject { YAML.load(result) }
-  let(:result) { described_class.new(lints).report_lints }
+  let(:result) { described_class.new(lints, []).report_lints }
 
   describe '#report_lints' do
     context 'when there are no lints' do

--- a/spec/scss_lint/reporter/default_reporter_spec.rb
+++ b/spec/scss_lint/reporter/default_reporter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SCSSLint::Reporter::DefaultReporter do
-  subject { SCSSLint::Reporter::DefaultReporter.new(lints) }
+  subject { SCSSLint::Reporter::DefaultReporter.new(lints, []) }
 
   describe '#report_lints' do
     context 'when there are no lints' do

--- a/spec/scss_lint/reporter/files_reporter_spec.rb
+++ b/spec/scss_lint/reporter/files_reporter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SCSSLint::Reporter::FilesReporter do
-  subject { described_class.new(lints) }
+  subject { described_class.new(lints, []) }
 
   describe '#report_lints' do
     context 'when there are no lints' do

--- a/spec/scss_lint/reporter/json_reporter_spec.rb
+++ b/spec/scss_lint/reporter/json_reporter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SCSSLint::Reporter::JSONReporter do
-  subject { SCSSLint::Reporter::JSONReporter.new(lints) }
+  subject { SCSSLint::Reporter::JSONReporter.new(lints, []) }
 
   describe '#report_lints' do
     let(:json) { JSON.parse(subject.report_lints) }


### PR DESCRIPTION
Fixes #430

I realized that #430 was essentially a request for a reporter, not a config option. Here's an implementation. I like the idea of the reporter having access to all of the files that were linted, because people can write reporters with statistical elements, like what % of files are clean, what % of lines are clean, etc.