### PR TITLE
NestingDepth linter not handling rules with no selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add flexbox properties to `recess` preset sort order
 * Fix handling of consecutive control comments to properly disable linters
 * Fix handling of control comments preceded by normal comments
+* Fix `NestingDepth` linter not handling rules with no selectors
 
 ## 0.40.1
 

--- a/lib/scss_lint/linter/nesting_depth.rb
+++ b/lib/scss_lint/linter/nesting_depth.rb
@@ -30,6 +30,7 @@ module SCSSLint
 
     def ignore_selectors?(node)
       return unless config['ignore_parent_selectors']
+      return unless node.parsed_rules
 
       simple_selectors(node.parsed_rules).all? do |selector|
         IGNORED_SELECTORS.include?(selector.class)

--- a/spec/scss_lint/linter/nesting_depth_spec.rb
+++ b/spec/scss_lint/linter/nesting_depth_spec.rb
@@ -155,6 +155,22 @@ describe SCSSLint::Linter::NestingDepth do
 
         it { should_not report_lint }
       end
+
+      context 'and sequence contains a keyframe' do
+        let(:linter_config) { super().merge('max_depth' => 1) }
+        let(:scss) { <<-SCSS }
+        @keyframe my_keyframe {
+            0% {
+                background: none;
+            }
+            50% {
+                background: red;
+            }
+        }
+        SCSS
+
+        it { should_not report_lint }
+      end
     end
 
     context 'when not ignoring parent selectors' do


### PR DESCRIPTION
Hi Guys,

Noticed #541 so I've taken a look at this, when I wrote the initial implementation I didn't realise that `node.parsed_rules` could potentially return `nil`. If my understanding is correct a `RuleNode` can in some cases return `nil` when it contains no CSS selectors so I've gone for a somewhat quick and dirty null object, maybe an implicit `return` statement would do the job?

Hope this helps!