### PR TITLE
Fixes #547

### DIFF
--- a/lib/scss_lint/linter/nesting_depth.rb
+++ b/lib/scss_lint/linter/nesting_depth.rb
@@ -38,6 +38,8 @@ module SCSSLint
     end
 
     def simple_selectors(node)
+      return [] if node.nil?
+
       node.members.flat_map(&:members).reject do |simple_sequence|
         simple_sequence.is_a?(String)
       end.flat_map(&:members)


### PR DESCRIPTION
Simple PR resolves #547 by guarding against scenarios when `node.parsed_rules` returns `nil`. Not sure if this warrants a test. I remember reading over a few other issues that mentioned a sass internal returning `nil` unexpected instead of an empty array, and if I recall correctly, they didn't add any extra tests. 