### PR TITLE
Add support for flexbox-related properties into SMACSS property sort order file

### DIFF
--- a/data/property-sort-orders/smacss.txt
+++ b/data/property-sort-orders/smacss.txt
@@ -10,6 +10,19 @@ right
 bottom
 left
 
+flex
+flex-basis
+flex-direction
+flex-flow
+flex-grow
+flex-shrink
+flex-wrap
+align-content
+align-items
+align-self
+justify-content
+order
+
 width
 min-width
 max-width


### PR DESCRIPTION
The existing SMACSS property sort file puts all flexbox-related properties to the end of the list (because they are not explicitly defined), which does not work well with modern CSS.

This PR addresses this inconsistency by adding a list of all common flexbox-related properties to the "Box" section. Old flexbox syntax is not considered as it has the same status as vendor-specific properties.