### PR TITLE
Fix newlines in MergeableRule lint message

### DIFF
--- a/lib/scss_lint/linter/mergeable_selector.rb
+++ b/lib/scss_lint/linter/mergeable_selector.rb
@@ -11,8 +11,10 @@ module SCSSLint
         seen_nodes << child_node
         next unless mergeable_node
 
+        rule_text = node_rule(child_node).gsub(/(\r?\n)+/, ' ')
+
         add_lint child_node.line,
-                 "Merge rule `#{node_rule(child_node)}` with rule " \
+                 "Merge rule `#{rule_text}` with rule " \
                  "on line #{mergeable_node.line}"
       end
 


### PR DESCRIPTION
Fixes #545 


Example `d.scss`:

```scss
.foo,
.bar {
  margin: 1px;
}

.foo,
.bar {
  padding: 1px;
}
```

Linting used to produce:

```
$ bundle exec bin/scss-lint d.scss
d.scss:6 [W] MergeableSelector: Merge rule `.foo,
.bar` with rule on line 1
```

Becomes:

```
$ bundle exec bin/scss-lint d.scss
d.scss:6 [W] MergeableSelector: Merge rule `.foo, .bar` with rule on line 1
```