### PR TITLE
Adds linter for transition all (#556)

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -201,6 +201,9 @@ linters:
   TrailingZero:
     enabled: false
 
+  TransitionAll:
+    enabled: false
+
   UnnecessaryMantissa:
     enabled: true
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -51,6 +51,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [TrailingSemicolon](#trailingsemicolon)
 * [TrailingWhitespace](#trailingwhitespace)
 * [TrailingZero](#trailingzero)
+* [TransitionAll](#transitionall)
 * [UnnecessaryMantissa](#unnecessarymantissa)
 * [UnnecessaryParentReference](#unnecessaryparentreference)
 * [UrlFormat](#urlformat)
@@ -1481,6 +1482,22 @@ margin: .5em;
 
 The extra zeros are unnecessary and just add additional bytes to the resulting
 generated CSS.
+
+## TransitionAll
+
+**Disabled by default**
+
+Don't use the all keyword to specify transition properties.
+
+**Bad: use of transition all**
+```scss
+transition: all .5s ease-in;
+```
+
+**Good: explicitly specify properties to transition**
+```scss
+transition: color .5s ease-in, margin-bottom .5s ease-in;
+```
 
 ## UnnecessaryMantissa
 

--- a/lib/scss_lint/linter/transition_all.rb
+++ b/lib/scss_lint/linter/transition_all.rb
@@ -1,5 +1,5 @@
 module SCSSLint
-  # Checks for explicitly transitioning properties instead of transition all.
+  # Checks for explicitly transitioned properties instead of transition all.
   class Linter::TransitionAll < Linter
     include LinterRegistry
 
@@ -23,7 +23,7 @@ module SCSSLint
       pos = node.value_source_range.start_pos.after(value[0, offset])
 
       add_lint(Location.new(pos.line, pos.offset, 3),
-               "#{property} should contain explicity properties " \
+               "#{property} should contain explicit properties " \
                 'instead of using the keyword all')
     end
   end

--- a/lib/scss_lint/linter/transition_all.rb
+++ b/lib/scss_lint/linter/transition_all.rb
@@ -1,0 +1,30 @@
+module SCSSLint
+  # Checks for explicitly transitioning properties instead of transition all.
+  class Linter::TransitionAll < Linter
+    include LinterRegistry
+
+    TRANSITION_PROPERTIES = %w[
+      transition
+      transition-property
+    ]
+
+    def visit_prop(node)
+      property = node.name.first.to_s
+      return unless TRANSITION_PROPERTIES.include?(property)
+
+      check_transition(node, property, node.value.to_sass)
+    end
+
+  private
+
+    def check_transition(node, property, value)
+      return unless offset = value =~ /\ball\b/
+
+      pos = node.value_source_range.start_pos.after(value[0, offset])
+
+      add_lint(Location.new(pos.line, pos.offset, 3),
+               "#{property} should contain explicity properties " \
+                'instead of using the keyword all')
+    end
+  end
+end

--- a/spec/scss_lint/linter/transition_all_spec.rb
+++ b/spec/scss_lint/linter/transition_all_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::TransitionAll do
+  context 'when transition-property is not set' do
+    let(:scss) { <<-SCSS }
+      p {
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when transition-property is set to none' do
+    let(:scss) { <<-SCSS }
+      p {
+        transition-property: none;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when transition-property is not set to all' do
+    let(:scss) { <<-SCSS }
+      p {
+        transition-property: color;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when transition-property is set to all' do
+    let(:scss) { <<-SCSS }
+      p {
+        transition-property: all;
+      }
+    SCSS
+
+    it { should report_lint line: 2 }
+  end
+
+  context 'when transition shorthand for transition-property is not set' do
+    let(:scss) { <<-SCSS }
+      p {
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when transition shorthand for transition-property is set to none' do
+    let(:scss) { <<-SCSS }
+      p {
+        transition: none;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when transition shorthand for transition-property is not set to all' do
+    let(:scss) { <<-SCSS }
+      p {
+        transition: color 1s linear;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when transition shorthand for transition-property is set to all' do
+    let(:scss) { <<-SCSS }
+      p {
+        transition: all 1s linear;
+      }
+    SCSS
+
+    it { should report_lint line: 2 }
+  end
+end


### PR DESCRIPTION
This PR addresses #556 by adding a `TransitionAll` linter that enforces explicit declaration of properties to be transitioned instead of using `transition: all` or `transition-property: all` (discussion about the validity of this preference can be found in the issue).

I have set the linter to be disabled by default, because I wasn't sure if it should be enabled. I think it's a fairly common sense linter to enable, but if there is a compelling reason why it shouldn't be, it can be left as is.

I've updated the docs and tried to add as helpful of error messages as possible. The best I could come up with was:

> {transition/transition-property} should contain explicit properties instead of using the keyword all

I'm definitely open to alternative phrasings, though.

Also one thing to note: To test if the `all` keyword is used, I've done a word-boundaried regex on the value of `transition` or `transition-property`. This of course could report false positives in very strange cases, but it seems like this approach is used by other linters, so I assumed it was accepted. If there is a better way though, I'd love to hear about it.