### PR TITLE
Improve ColorVariable to flag uses of rgb/rgba/hsl/hsla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `SpaceAroundOperator` linter to not report false positives operators in
   interpolation
+* Improve `ColorVariable` to flag uses of rgb/rgba/hsl/hsla
 
 ## 0.41.0
 

--- a/spec/scss_lint/linter/color_variable_spec.rb
+++ b/spec/scss_lint/linter/color_variable_spec.rb
@@ -127,7 +127,7 @@ describe SCSSLint::Linter::ColorVariable do
       }
     SCSS
 
-    it { should_not report_lint }
+    it { should report_lint line: 2 }
   end
 
   context 'when a color literal is used in a map declaration' do
@@ -160,6 +160,46 @@ describe SCSSLint::Linter::ColorVariable do
       /*!
        * test \#{a}
        */
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when a color function containing literals is used in a property' do
+    let(:scss) { <<-SCSS }
+      p {
+        color: rgb(0, 100, 200);
+      }
+      a {
+        color: rgb(0%, 50%, 80%);
+      }
+      i {
+        color: rgba(0, 0, 0, .5);
+      }
+      span {
+        color: hsl(0, 100%, 50%);
+      }
+      .class {
+        color: hsla(0, 100%, 50%, .5);
+      }
+    SCSS
+
+    it { should report_lint line: 2 }
+    it { should report_lint line: 5 }
+    it { should report_lint line: 8 }
+    it { should report_lint line: 11 }
+    it { should report_lint line: 14 }
+  end
+
+  context 'when transforming a variable value in a function call' do
+    let(:scss) { <<-SCSS }
+      p {
+        color: rgba($red, .5);
+      }
+
+      a {
+        color: lighten($red, 5%);
+      }
     SCSS
 
     it { should_not report_lint }


### PR DESCRIPTION
Hey Folks, 

I've started working on https://github.com/brigade/scss-lint/issues/488 and I was hoping to get some feedback before completing this. I've added some specs based on the examples in the matrix and these are now passing. There are a couple of things to note, as we're simply checking all of the color function arguments are literals then we won't raise a lint in the case where we have a mixture of variables and literals, so the example below won't raise a lint, would my implementation need to handle this too?

```css
  a {
    color: rgb($some-var, 50%, 80%);
  }
```

Also I've changed this [spec](https://github.com/cih/scss-lint/blob/1759e748bc4b0017c94154561c56baf773e04202/spec/scss_lint/linter/color_variable_spec.rb#L123-L131) to expect a lint to be reported, this was previously expected to not report, what would we want to happen in this case. Any feedback would be appreciated.

Thanks!