### PR TITLE
Support any command line flags in the rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Dependency Status](https://gemnasium.com/brigade/scss-lint.svg)](https://gemnasium.com/brigade/scss-lint)
 
 `scss-lint` is a tool to help keep your [SCSS](http://sass-lang.com) files
-clean and readable. You can run it manually from the command-line, or integrate
+clean and readable. You can run it manually from the command line, or integrate
 it into your [SCM hooks](https://github.com/brigade/overcommit).
 
 * [Requirements](#requirements)
@@ -55,7 +55,7 @@ context in which you are linting, nowhere else.
 
 ## Usage
 
-Run `scss-lint` from the command-line by passing in a directory (or multiple
+Run `scss-lint` from the command line by passing in a directory (or multiple
 directories) to recursively scan:
 
 ```bash
@@ -463,9 +463,14 @@ require 'scss_lint/rake_task'
 
 SCSSLint::RakeTask.new do |t|
   t.config = 'custom/config.yml'
+  t.args = ['--formatter', 'JSON', '--out', 'results.txt']
   t.files = ['app/assets', 'custom/*.scss']
 end
 ```
+
+You can specify any command line arguments in the `args` attribute that are
+allowed by the `scss-lint` Ruby binary script. Each argument must be passed as
+an Array element, rather than one String with spaces.
 
 You can also use this custom configuration with a set of files specified via
 the command line:

--- a/lib/scss_lint/rake_task.rb
+++ b/lib/scss_lint/rake_task.rb
@@ -31,6 +31,10 @@ module SCSSLint
     # @return [String]
     attr_accessor :config
 
+    # Command-line args to use.
+    # @return [Array<String>]
+    attr_accessor :args
+
     # List of files to lint (can contain shell globs).
     #
     # Note that this will be ignored if you explicitly pass a list of files as
@@ -67,7 +71,7 @@ module SCSSLint
     def run_cli(task_args)
       cli_args = ['--config', config] if config
 
-      result = SCSSLint::CLI.new.run(Array(cli_args) + files_to_lint(task_args))
+      result = SCSSLint::CLI.new.run(Array(cli_args) + Array(args) + files_to_lint(task_args))
 
       message =
         case result
@@ -98,6 +102,7 @@ module SCSSLint
     def default_description
       description = 'Run `scss-lint'
       description += " --config #{config}" if config
+      description += " #{args}" if args
       description += " #{files.join(' ')}" if files.any?
       description += ' [files...]`'
       description

--- a/spec/scss_lint/rake_task_spec.rb
+++ b/spec/scss_lint/rake_task_spec.rb
@@ -3,12 +3,12 @@ require 'scss_lint/rake_task'
 require 'tempfile'
 
 describe SCSSLint::RakeTask do
-  before(:all) do
-    SCSSLint::RakeTask.new
-  end
-
   before do
     STDOUT.stub(:write) # Silence console output
+  end
+
+  after(:each) do
+    Rake::Task['scss_lint'].clear if Rake::Task.task_defined?('scss_lint')
   end
 
   let(:file) do
@@ -25,19 +25,68 @@ describe SCSSLint::RakeTask do
     end
   end
 
-  context 'when SCSS document is valid with no lints' do
+  context 'basic RakeTask' do
+    before(:each) do
+      SCSSLint::RakeTask.new
+    end
+
+    context 'when SCSS document is valid with no lints' do
+      let(:scss) { '' }
+
+      it 'does not call Kernel.exit' do
+        expect { run_task }.not_to raise_error
+      end
+    end
+
+    context 'when SCSS document is invalid' do
+      let(:scss) { '.class {' }
+
+      it 'calls Kernel.exit with the status code' do
+        expect { run_task }.to raise_error SystemExit
+      end
+    end
+  end
+
+  context 'configured RakeTask with a config file' do
     let(:scss) { '' }
 
-    it 'does not call Kernel.exit' do
+    let(:config_file) do
+      config = Tempfile.new(%w[foo .yml])
+      config.write('')
+      config.close
+      config.path
+    end
+
+    it 'passes config files to the CLI' do
+      SCSSLint::RakeTask.new.tap do |t|
+        t.config = config_file
+      end
+
+      cli = double(SCSSLint::CLI)
+      SCSSLint::CLI.should_receive(:new) { cli }
+      args = ['--config', config_file, file.path]
+      cli.should_receive(:run).with(args) { 0 }
+
       expect { run_task }.not_to raise_error
     end
   end
 
-  context 'when SCSS document is invalid' do
-    let(:scss) { '.class {' }
+  context 'configured RakeTask with args' do
+    let(:scss) { '' }
 
-    it 'calls Kernel.exit with the status code' do
-      expect { run_task }.to raise_error SystemExit
+    it 'passes args to the CLI' do
+      formatter_args = ['--formatter', 'JSON']
+
+      SCSSLint::RakeTask.new.tap do |t|
+        t.args = formatter_args
+      end
+
+      cli = double(SCSSLint::CLI)
+      SCSSLint::CLI.should_receive(:new) { cli }
+      args = formatter_args + [file.path]
+      cli.should_receive(:run).with(args) { 0 }
+
+      expect { run_task }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Fixes #570

This PR allows blanket option passing into the Rake task (similar to other tools' implementations, like [Cucumber](https://github.com/cucumber/cucumber/wiki/Using-Rake)).

I'd like to somehow deprecate the `@config` piece, so that all options are just passed in with `@args`, and display that it is deprecated, but I didn't implement this.