### PR TITLE
Include MIT-LICENSE in gemspec

### DIFF
--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
 
   s.files            = Dir['config/**/*.yml'] +
                        Dir['data/**/*'] +
-                       Dir['lib/**/*.rb']
+                       Dir['lib/**/*.rb'] +
+                       ['MIT-LICENSE']
 
   s.test_files       = Dir['spec/**/*']
 


### PR DESCRIPTION
The MIT License should be included with any distribution of the code. This adds `MIT-LICENSE` to the gemspec.