### PR TITLE
Don't plow over @else nodes in ElsePlacement

### DIFF
--- a/lib/scss_lint/linter/else_placement.rb
+++ b/lib/scss_lint/linter/else_placement.rb
@@ -7,6 +7,7 @@ module SCSSLint
     def visit_if(node)
       visit_else(node, node.else) if node.else
       yield # Lint nested @if statements
+      visit(node.else) if node.else
     end
 
     def visit_else(if_node, else_node)

--- a/lib/scss_lint/sass/tree.rb
+++ b/lib/scss_lint/sass/tree.rb
@@ -104,7 +104,7 @@ module Sass::Tree
 
   class IfNode
     def children
-      concat_expr_lists super, expr, self.else
+      concat_expr_lists super, expr
     end
   end
 


### PR DESCRIPTION
Fixes #562 

With every `@if`, `@else if`, and `@else` node, we were attaching all of the following `@else if`s and `@else`s. We should instead not do that, and in every `visit_if`, do something closer to what [Sass does](https://github.com/sass/sass/blob/master/lib/sass/tree/visitors/base.rb#L66..L70).