### PR TITLE
Safer character_at()

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem 'rubocop', '0.33.0'
 gem 'travis', '~> 1.7'
 
 gem 'coveralls'
+gem 'ruby-prof'

--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -68,7 +68,7 @@ module SCSSLint
       actual_line   = source_position.line - 1
       actual_offset = source_position.offset + offset - 1
 
-      engine.lines[actual_line][actual_offset]
+      engine.lines.size > actual_line && engine.lines[actual_line][actual_offset]
     end
 
     # Extracts the original source code given a range.


### PR DESCRIPTION
Fixes #574 

There might be a more specific solution, but I saw that Sass thinks these nodes have an end_pos that is on the line _after_ the file ends. Lame.