### PR TITLE
Conservatively process control commands

### DIFF
--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -127,9 +127,9 @@ module SCSSLint
         visit_selector(node.parsed_rules)
       end
 
-      @comment_processor.before_node_visit(node)
+      @comment_processor.before_node_visit(node) if @engine.any_control_commands
       super
-      @comment_processor.after_node_visit(node)
+      @comment_processor.after_node_visit(node) if @engine.any_control_commands
     end
 
     # Redefine so we can set the `node_parent` of each node


### PR DESCRIPTION
Processing control command comments on every single node in a file (`Linter#visit`), for every single linter, seems heavy. I've changed the workflow to only search for control commands if the file has any at all (presumably, most files don't).

Linting Bootstrap 4 Alpha took ~11 seconds before this fix, and ~9 seconds after this fix.