### PR TITLE
Fix VariableForProperty lint when used with !important

### DIFF
--- a/lib/scss_lint/linter/variable_for_property.rb
+++ b/lib/scss_lint/linter/variable_for_property.rb
@@ -15,12 +15,20 @@ module SCSSLint
       return unless @properties.include?(property_name)
       return if ignored_value?(node.value)
       return if node.children.first.is_a?(Sass::Script::Tree::Variable)
+      return if variable_property_with_important?(node.value)
 
       add_lint(node, "Property #{property_name} should use " \
                      'a variable rather than a literal value')
     end
 
   private
+
+    def variable_property_with_important?(value)
+      value.is_a?(Sass::Script::Tree::ListLiteral) &&
+        value.children.length == 2 &&
+        value.children.first.is_a?(Sass::Script::Tree::Variable) &&
+        value.children.last.value.value == '!important'
+    end
 
     def ignored_value?(value)
       value.respond_to?(:value) &&

--- a/spec/scss_lint/linter/variable_for_property_spec.rb
+++ b/spec/scss_lint/linter/variable_for_property_spec.rb
@@ -88,6 +88,16 @@ describe SCSSLint::Linter::VariableForProperty do
       it { should report_lint line: 3 }
     end
 
+    context 'when configured property value is used with !important' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: $black !important;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
     context 'when property specifies `currentColor`' do
       let(:scss) { <<-SCSS }
         p {


### PR DESCRIPTION
For this example: 
```scss
.test {
  color: $silver !important;
}
```
The linter outputs:
```
test.scss:2 [W] ImportantRule: !important should not be used
test.scss:2 [W] VariableForProperty: Property color should use a variable rather than a literal value
```
I added a PR to handle the case when a variable is used with `!important`. 

---

Actually, when I looked at this lint a little more closely, I'm curious how this rule would play with something like `font: $large arial, sans-serif;`. What is the expected output?