### PR TITLE
Fix TrailingSemicolon for variables with !default and !global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SCSS-Lint Changelog
 
+## master (unreleased)
+
+* Fix `TrailingSemicolon` for variables with `!default` and `!global`.
+
 ## 0.42.0
 
 ### New Features

--- a/lib/scss_lint/linter/trailing_semicolon.rb
+++ b/lib/scss_lint/linter/trailing_semicolon.rb
@@ -8,6 +8,13 @@ module SCSSLint
     end
 
     def visit_variable(node)
+      # If the variable is using `!default` or `!global` (e.g. `$foo: bar
+      # !default;`) then `node.expr` will give us the source range just for the
+      # value (e.g. `bar`). In these cases, we want to use the source range of
+      # `node`, which will give us most of the entire line (e.g. `foo: bar
+      # !default`.
+      return check_semicolon(node) if node.global || node.guarded
+
       check_semicolon(node.expr)
     end
 

--- a/spec/scss_lint/linter/trailing_semicolon_spec.rb
+++ b/spec/scss_lint/linter/trailing_semicolon_spec.rb
@@ -23,6 +23,48 @@ describe SCSSLint::Linter::TrailingSemicolon do
     it { should_not report_lint }
   end
 
+  context 'when an !important property' do
+    context 'ends with a semicolon' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0 !important;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'ends with two semicolons' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0 !important;;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'has a space before the semicolon' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0 !important ;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is missing a semicolon' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0 !important
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+  end
+
   context 'when a property ends with a space followed by a semicolon' do
     let(:scss) { <<-SCSS }
       p {
@@ -302,6 +344,84 @@ describe SCSSLint::Linter::TrailingSemicolon do
     it { should_not report_lint }
   end
 
+  context 'when a !default variable declaration' do
+    context 'ends with a semicolon' do
+      let(:scss) { '$foo: bar !default;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'ends with two semicolons' do
+      let(:scss) { '$foo: bar !default;;' }
+
+      it { should report_lint }
+    end
+
+    context 'has a space before the semicolon' do
+      let(:scss) { '$foo: bar !default ;' }
+
+      it { should report_lint }
+    end
+
+    context 'is missing a semicolon' do
+      let(:scss) { '$foo: bar !default' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when a !global variable declaration' do
+    context 'ends with a semicolon' do
+      let(:scss) { '$foo: bar !global;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'ends with two semicolons' do
+      let(:scss) { '$foo: bar !global;;' }
+
+      it { should report_lint }
+    end
+
+    context 'has a space before the semicolon' do
+      let(:scss) { '$foo: bar !global ;' }
+
+      it { should report_lint }
+    end
+
+    context 'is missing a semicolon' do
+      let(:scss) { '$foo: bar !global' }
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when the value of the variable is !important' do
+    context 'ends with a semicolon' do
+      let(:scss) { '$foo: bar !important;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'ends with two semicolons' do
+      let(:scss) { '$foo: bar !important;;' }
+
+      it { should report_lint }
+    end
+
+    context 'has a space before the semicolon' do
+      let(:scss) { '$foo: bar !important ;' }
+
+      it { should report_lint }
+    end
+
+    context 'is missing a semicolon' do
+      let(:scss) { '$foo: bar !important' }
+
+      it { should report_lint }
+    end
+  end
+
   context 'when variable declaration is followed by a comment and semicolon' do
     let(:scss) { '$foo: bar // comment;' }
 
@@ -348,6 +468,90 @@ describe SCSSLint::Linter::TrailingSemicolon do
         let(:scss) { "$foo: (\n  one: 1,\ntwo: 2\n)" }
 
         it { should report_lint }
+      end
+    end
+  end
+
+  context 'with an @extend directive' do
+    context 'that ends with a semicolon' do
+      let(:scss) { <<-SCSS }
+        .foo {
+          @extend .bar;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'with two semicolons' do
+      let(:scss) { <<-SCSS }
+        .foo {
+          @extend .bar;;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'with a space before the semicolon' do
+      let(:scss) { <<-SCSS }
+        .foo {
+          @extend .bar ;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'that does not have a semicolon' do
+      let(:scss) { <<-SCSS }
+        .foo {
+          @extend .bar
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'with the !optional flag' do
+      context 'that ends with a semicolon' do
+        let(:scss) { <<-SCSS }
+          .foo {
+            @extend .bar !optional;
+          }
+        SCSS
+
+        it { should_not report_lint }
+      end
+
+      context 'with two semicolons' do
+        let(:scss) { <<-SCSS }
+          .foo {
+            @extend .bar !optional;;
+          }
+        SCSS
+
+        it { should report_lint line: 2 }
+      end
+
+      context 'with a space before the semicolon' do
+        let(:scss) { <<-SCSS }
+          .foo {
+            @extend .bar !optional ;
+          }
+        SCSS
+
+        it { should report_lint line: 2 }
+      end
+
+      context 'that does not have a semicolon' do
+        let(:scss) { <<-SCSS }
+          .foo {
+            @extend .bar !optional
+          }
+        SCSS
+
+        it { should report_lint line: 2 }
       end
     end
   end


### PR DESCRIPTION
The TrailingSemicolon rule was not checking guarded or global variable
declarations properly. I determined that this is because we are using
`node.expr` for the source range, which in cases like:

  $foo: bar !default;

gives us a range that looks like:

  bar

which causes the linter to fail. Instead, if we just use the `node`
source range instead, we will get

  foo: bar !default;

so our checks work as expected. I considered always using `node` source
range, but I figured that if it is working for other cases that it would
be better to leave it as is.

Addresses #602