### PR TITLE
Check !default, !global, and !optional flags in BangFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master (unreleased)
 
 * Fix `TrailingSemicolon` for variables with `!default` and `!global`.
+* Check `!default` and `!global` variable declarations and `!optional` `@extend`
+  directives in `BangFormat`
 
 ## 0.42.0
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -62,7 +62,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 
 ## BangFormat
 
-Reports when you use improper spacing around `!` (the "bang") in `!important` and `!default` declarations.
+Reports when you use improper spacing around `!` (the "bang") in `!default`, `!global`, `!important`, and `!optional` flags.
 
 You can prefer a single space or no space both before and after the `!`.
 

--- a/spec/scss_lint/linter/bang_format_spec.rb
+++ b/spec/scss_lint/linter/bang_format_spec.rb
@@ -77,6 +77,64 @@ describe SCSSLint::Linter::BangFormat do
     it { should_not report_lint }
   end
 
+  context 'with a !default variable declaration' do
+    context 'and !default is used correctly' do
+      let(:scss) { <<-SCSS }
+        $foo: bar !default;
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'and there is no space before' do
+      let(:scss) { <<-SCSS }
+        $foo: bar!default;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'with a !global variable declaration' do
+    context 'and !global is used correctly' do
+      let(:scss) { <<-SCSS }
+        $foo: bar !global;
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'and there is no space before' do
+      let(:scss) { <<-SCSS }
+        $foo: bar!global;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'with an !optional @extend directive' do
+    context 'and !optional is used correctly' do
+      let(:scss) { <<-SCSS }
+        .foo {
+          @extend .bar !optional;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'and there is no space before' do
+      let(:scss) { <<-SCSS }
+        .foo {
+          @extend .bar!optional;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+  end
+
   context 'when ! appears within a string' do
     let(:scss) { <<-SCSS }
       p:before { content: "!important"; }


### PR DESCRIPTION
This linter was not visiting variable declarations or `@extend`
directives, so it was not checking for `!default`, `!global`, and
`!optional`.