### PR TITLE
Fix newlines around operators

### DIFF
--- a/lib/scss_lint/linter/space_around_operator.rb
+++ b/lib/scss_lint/linter/space_around_operator.rb
@@ -21,6 +21,7 @@ module SCSSLint
       yield
     end
 
+    # Making a public version of #source_from_range, a private method.
     def source_fm_range(range)
       source_from_range(range)
     end
@@ -34,11 +35,19 @@ module SCSSLint
         (?<right_space>\s*)
       /x)
 
+      # We forgive spacing with newlines. In the case of a newline occurring on
+      # one side or another, we don't care about indentation, and the
+      # TrailingWhitespace linter will worry about trailing whitespace, so we
+      # just don't worry about space with a newline.
+      left_newline = match[:left_space].include?("\n")
+      right_newline = match[:right_space].include?("\n")
       if config['style'] == 'one_space'
-        if match[:left_space] != ' ' || match[:right_space] != ' '
+        if (match[:left_space] != ' ' && !left_newline) ||
+          (match[:right_space] != ' ' && !right_newline)
           add_lint(node, operation_sources.space_msg(match[:operator]))
         end
-      elsif match[:left_space] != '' || match[:right_space] != ''
+      elsif (match[:left_space] != '' && !left_newline) ||
+        (match[:right_space] != '' && !right_newline)
         add_lint(node, operation_sources.no_space_msg(match[:operator]))
       end
     end

--- a/spec/scss_lint/linter/space_around_operator_spec.rb
+++ b/spec/scss_lint/linter/space_around_operator_spec.rb
@@ -60,18 +60,28 @@ describe SCSSLint::Linter::SpaceAroundOperator do
       it { should report_lint line: 10 }
     end
 
-    context 'when numeric values with infix operators and newlines exist' do
+    context 'when infix operators and newlines exist' do
       let(:scss) { <<-SCSS }
         p {
           margin: 7px+
+              7px;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when infix operators and newlines exist, but otherwise correct spacing' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 7px +
               7px;
           padding: 9px
               + 9px;
         }
       SCSS
 
-      it { should report_lint line: 2 }
-      it { should report_lint line: 4 }
+      it { should_not report_lint }
     end
 
     context 'when numeric values with multiple infix operators exist' do
@@ -232,7 +242,7 @@ describe SCSSLint::Linter::SpaceAroundOperator do
     end
   end
 
-  context 'when one space is preferred' do
+  context 'when no space is preferred' do
     let(:style) { 'no_space' }
 
     context 'when values with single-spaced infix operators exist' do


### PR DESCRIPTION
Fixes #598 by forgiving space around an operator with a newline.