### PR TITLE
Don't lint HexValidation on mid-word hex strings

### DIFF
--- a/lib/scss_lint/linter/hex_validation.rb
+++ b/lib/scss_lint/linter/hex_validation.rb
@@ -6,7 +6,7 @@ module SCSSLint
     def visit_script_string(node)
       return unless node.type == :identifier
 
-      node.value.scan(/(#\h+)/) do |match|
+      node.value.scan(/(?:\W|^)(#\h+)(?:\W|$)/) do |match|
         check_hex(match.first, node)
       end
     end

--- a/spec/scss_lint/linter/hex_validation_spec.rb
+++ b/spec/scss_lint/linter/hex_validation_spec.rb
@@ -37,4 +37,15 @@ describe SCSSLint::Linter::HexValidation do
     it { should report_lint line: 2 }
     it { should report_lint line: 3 }
   end
+
+  context 'when rule contains hex codes in a longer string' do
+    let(:scss) { <<-SCSS }
+      p {
+        content: 'foo#bad';
+        content: 'foo #ba';
+      }
+    SCSS
+
+    it { should report_lint line: 3 }
+  end
 end


### PR DESCRIPTION
Fixes #597 

I went with "non-word" (`\W`) separations, because word-break separations (`\b`) don't work with the `#` character.