### PR TITLE
Fix `ColorVariable` to ignore color functions in variable declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `SpaceAroundOperator` to allow newlines
 * Fix `HexValidation` to ignore mid-word hex strings
+* Fix `ColorVariable` to ignore color functions in variable declaration
 
 ## 0.42.1
 

--- a/lib/scss_lint/linter/color_variable.rb
+++ b/lib/scss_lint/linter/color_variable.rb
@@ -33,7 +33,7 @@ module SCSSLint
     end
 
     def visit_script_funcall(node)
-      if color_function?(node) && all_arguments_are_literals?(node)
+      if literal_color_function?(node)
         record_lint node, node.to_sass
       else
         yield
@@ -63,6 +63,10 @@ module SCSSLint
         parent.node_parent.is_a?(Sass::Tree::VariableNode)
     end
 
+    def function_in_variable_declaration?(node)
+      node.node_parent.is_a?(Sass::Tree::VariableNode)
+    end
+
     def in_rgba_function_call?(node)
       grandparent = node_ancestor(node, 2)
 
@@ -82,6 +86,12 @@ module SCSSLint
 
     def color_function?(node)
       COLOR_FUNCTIONS.include?(node.name)
+    end
+
+    def literal_color_function?(node)
+      color_function?(node) &&
+        all_arguments_are_literals?(node) &&
+        !function_in_variable_declaration?(node)
     end
   end
 end

--- a/spec/scss_lint/linter/color_variable_spec.rb
+++ b/spec/scss_lint/linter/color_variable_spec.rb
@@ -9,6 +9,14 @@ describe SCSSLint::Linter::ColorVariable do
     it { should_not report_lint }
   end
 
+  context 'when a color function containing literals is used in a variable declaration' do
+    let(:scss) { <<-SCSS }
+      $my-color: rgba(0, 0, 0, 0.2);
+    SCSS
+
+    it { should_not report_lint }
+  end
+
   context 'when a color literal is used in a property' do
     let(:scss) { <<-SCSS }
       p {


### PR DESCRIPTION
Hey Folks,

Not sure what way you are wanting to go on the discussion in https://github.com/brigade/scss-lint/issues/488 but this change updates the `ColorVariable` linter to ignore color functions within variable declarations. If there are any other cases that might need to be handled then let me know and I can update it.

Cheers!