### PR TITLE
Add a @@simple_name to Linter

### DIFF
--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -204,7 +204,7 @@ module SCSSLint
       puts 'Installed linters:'
 
       linter_names = LinterRegistry.linters.map do |linter|
-        linter.name.split('::').last
+        linter.simple_name
       end
 
       linter_names.sort.each do |linter_name|

--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -41,8 +41,7 @@ module SCSSLint
       end
 
       def linter_name(linter)
-        linter = linter.is_a?(Class) ? linter : linter.class
-        linter.name.split('::')[2..-1].join('::')
+        (linter.is_a?(Class) ? linter : linter.class).simple_name
       end
 
     private

--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -4,6 +4,24 @@ module SCSSLint
     include SelectorVisitor
     include Utils
 
+    @@simple_name = 'UNIMPLEMENTED'
+
+    class << self
+      attr_accessor :simple_name
+
+      # When defining a Linter class, define its simple name as well. This
+      # assumes that the module hierarchy of every linter starts with
+      # `SCSSLint::Linter::`, and removes this part of the class name.
+      #
+      # `SCSSLint::Linter::Foo.simple_name`          #=> "Foo"
+      # `SCSSLint::Linter::Compass::Bar.simple_name` #=> "Compass::Bar"
+      def inherited(linter)
+        name_parts = linter.name.split('::')
+        name = name_parts.length < 3 ? '' : name_parts[2..-1].join('::')
+        linter.simple_name = name
+      end
+    end
+
     attr_reader :config, :engine, :lints
 
     # Create a linter.
@@ -29,7 +47,7 @@ module SCSSLint
     # Return the human-friendly name of this linter as specified in the
     # configuration file and in lint descriptions.
     def name
-      self.class.name.split('::')[2..-1].join('::')
+      self.class.simple_name
     end
 
   protected

--- a/lib/scss_lint/selector_visitor.rb
+++ b/lib/scss_lint/selector_visitor.rb
@@ -22,13 +22,21 @@ module SCSSLint
       end
     end
 
+    # The class name of a node, in snake_case form, e.g.
+    # `Sass::Selector::SimpleSequence` -> `simple_sequence`.
+    #
+    # The name is memoized as a class variable on the node itself.
     def selector_node_name(node)
-      # Converts the class name of a node into snake_case form, e.g.
-      # `Sass::Selector::SimpleSequence` -> `simple_sequence`
-      name = node.class.name.gsub(/.*::(.*?)$/, '\\1')
+      if node.class.class_variable_defined?(:@@snake_case_name)
+        return node.class.class_variable_get(:@@snake_case_name)
+      end
+
+      rindex = node.class.name.rindex('::')
+      name = node.class.name[(rindex+2)..-1]
       name.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
       name.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
       name.downcase!
+      node.class.class_variable_set(:@@snake_case_name, name)
     end
   end
 end


### PR DESCRIPTION
This is a performance boost. I'm adding a `@@linter_name` to each Linter class as it inherits `Linter`. I used stackprof to profile linting (4 copies of) Bootstrap 4's SCSS files, and found that a lot of time was spent in Config.linter_name, Linter#name and a **ton** of time in SelectorVisitor#selector_node_name.

This refactoring computes the simple name of a linter once, memoizing the result for all of these methods.

In that Bootstrap 4 case, this drove the time to lint down from 20 seconds to 15 seconds!