### PR TITLE
Improve character_at with other methods

### DIFF
--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -61,16 +61,6 @@ module SCSSLint
       Location.new(range.start_pos.line, range.start_pos.offset, length)
     end
 
-    # @param source_position [Sass::Source::Position]
-    # @param offset [Integer]
-    # @return [String] the character at the given [Sass::Source::Position]
-    def character_at(source_position, offset = 0)
-      actual_line   = source_position.line - 1
-      actual_offset = source_position.offset + offset - 1
-
-      engine.lines.size > actual_line && engine.lines[actual_line][actual_offset]
-    end
-
     # Extracts the original source code given a range.
     #
     # @param source_range [Sass::Source::Range]
@@ -156,6 +146,34 @@ module SCSSLint
       else
         Location.new(node_or_line_or_location)
       end
+    end
+
+    # @param source_position [Sass::Source::Position]
+    # @param offset [Integer]
+    # @return [String] the character at the given [Sass::Source::Position]
+    def character_at(source_position, offset = 0)
+      actual_line   = source_position.line - 1
+      actual_offset = source_position.offset + offset - 1
+
+      engine.lines.size > actual_line && engine.lines[actual_line][actual_offset]
+    end
+
+    # Starting at source_position (plus offset), search for pattern and return
+    # the offset from the source_position.
+    #
+    # @param source_position [Sass::Source::Position]
+    # @param pattern [String, RegExp] the pattern to search for
+    # @param offset [Integer]
+    # @return [Integer] the offset at which [pattern] was found.
+    def offset_to(source_position, pattern, offset = 0)
+      actual_line   = source_position.line - 1
+      actual_offset = source_position.offset + offset - 1
+
+      return nil if actual_line >= engine.lines.size
+
+      actual_index = engine.lines[actual_line].index(pattern, actual_offset)
+
+      actual_index && actual_index + 1 - source_position.offset
     end
   end
 end

--- a/lib/scss_lint/linter/space_after_property_colon.rb
+++ b/lib/scss_lint/linter/space_after_property_colon.rb
@@ -73,16 +73,15 @@ module SCSSLint
 
     def whitespace_after_colon(node)
       whitespace = []
-      offset = 1
+      offset = 0
+      start_pos = node.name_source_range.start_pos
 
       # Find the colon after the property name
-      while character_at(node.name_source_range.start_pos, offset - 1) != ':'
-        offset += 1
-      end
+      offset = offset_to(start_pos, ':', offset) + 1
 
       # Count spaces after the colon
-      while [' ', "\t", "\n"].include? character_at(node.name_source_range.start_pos, offset)
-        whitespace << character_at(node.name_source_range.start_pos, offset)
+      while [' ', "\t", "\n"].include? character_at(start_pos, offset)
+        whitespace << character_at(start_pos, offset)
         offset += 1
       end
 

--- a/lib/scss_lint/linter/space_after_property_name.rb
+++ b/lib/scss_lint/linter/space_after_property_name.rb
@@ -15,13 +15,7 @@ module SCSSLint
     # Deals with a weird Sass bug where the name_source_range of a PropNode does
     # not start at the beginning of the property name.
     def property_name_colon_offset(node)
-      offset = 0
-
-      while character_at(node.name_source_range.start_pos, offset) != ':'
-        offset += 1
-      end
-
-      offset
+      offset_to(node.name_source_range.start_pos, ':')
     end
   end
 end


### PR DESCRIPTION
This is a performance boosting change.

* move `character_at` to be private.
* Add an `offset_to` method to be used instead of `character_at` in a few cases. These were cases where a method was walking character by character, searching for something specific. This is made much faster with `offset_to`.