### PR TITLE
EmptyLineBetweenBlocks lints on @media and @at-root now

### DIFF
--- a/lib/scss_lint/linter/empty_line_between_blocks.rb
+++ b/lib/scss_lint/linter/empty_line_between_blocks.rb
@@ -3,8 +3,18 @@ module SCSSLint
   class Linter::EmptyLineBetweenBlocks < Linter
     include LinterRegistry
 
+    def visit_atroot(node)
+      check(node, '@at-root')
+      yield
+    end
+
     def visit_function(node)
       check(node, '@function')
+      yield
+    end
+
+    def visit_media(node)
+      check(node, '@media')
       yield
     end
 

--- a/spec/scss_lint/linter/empty_line_between_blocks_spec.rb
+++ b/spec/scss_lint/linter/empty_line_between_blocks_spec.rb
@@ -102,6 +102,68 @@ describe SCSSLint::Linter::EmptyLineBetweenBlocks do
     it { should_not report_lint }
   end
 
+  context 'when at-roots are defined' do
+    context 'and there is no blank line between them' do
+      let(:scss) { <<-SCSS }
+        div {
+          @at-root {
+            p {
+            }
+          }
+          @at-root {
+            p {
+            }
+          }
+        }
+      SCSS
+
+      it { should report_lint line: 5 }
+    end
+
+    context 'and there is a blank line between them' do
+      let(:scss) { <<-SCSS }
+        div {
+          @at-root {
+            p {
+            }
+          }
+
+          @at-root {
+            p {
+            }
+          }
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when media blocks are defined' do
+    context 'and there is no blank line between them' do
+      let(:scss) { <<-SCSS }
+        @media screen {
+        }
+        @media print {
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'and there is a blank line between them' do
+      let(:scss) { <<-SCSS }
+        @media screen {
+        }
+
+        @media print {
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
   context 'when mixins are defined' do
     context 'and there is no blank line between them' do
       let(:scss) { <<-SCSS }


### PR DESCRIPTION
This partially addresses #538.

This only affects @media and @at-root, which are not control flow. It seems like EmptyLineBetweenBlocks should always expect empty lines around these.