### PR TITLE
Add placeholder and -ms-* to PseudoElement Linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SCSS-Lint Changelog
 
+## master (unreleased)
+
+* Add `placeholder`, `-moz-*`, `-ms-*`, and `-webkit-*` to `PseudoElement`
+  linter
+
 ## 0.43.0
 
 ### New Features

--- a/lib/scss_lint/linter/pseudo_element.rb
+++ b/lib/scss_lint/linter/pseudo_element.rb
@@ -3,7 +3,27 @@ module SCSSLint
   class Linter::PseudoElement < Linter
     include LinterRegistry
 
-    PSEUDO_ELEMENTS = %w[after backdrop before first-letter first-line selection]
+    # https://msdn.microsoft.com/en-us/library/windows/apps/hh767361.aspx
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions
+    PSEUDO_ELEMENTS = %w[
+      after backdrop before first-letter first-line placeholder selection
+
+      -moz-progress-bar -moz-anonymous-block -moz-anonymous-positioned-block
+      -moz-canvas -moz-cell-content -moz-focus-inner -moz-focus-outer
+      -moz-inline-table -moz-page -moz-page-sequence -moz-pagebreak
+      -moz-pagecontent -moz-placeholder -moz-progress-bar -moz-range-thumb
+      -moz-range-track -moz-selection -moz-scrolled-canvas -moz-scrolled-content
+      -moz-scrolled-page-sequence -moz-svg-foreign-content -moz-table
+      -moz-table-cell -moz-table-column -moz-table-column-group -moz-table-outer
+      -moz-table-row -moz-table-row-group -moz-viewport -moz-viewport-scroll
+      -moz-xul-anonymous-block
+
+      -ms-expand -ms-browse -ms-check -ms-clear -ms-expand -ms-fill
+      -ms-fill-lower -ms-fill-upper -ms-reveal -ms-thumb -ms-ticks-after
+      -ms-ticks-before -ms-tooltip -ms-track -ms-value
+
+      -webkit-progress-bar -webkit-progress-value
+    ]
 
     def visit_pseudo(pseudo)
       if PSEUDO_ELEMENTS.include?(pseudo.name)


### PR DESCRIPTION
I noticed that this linter didn't include these, which are currently
giving false positives on my codebase.

I found the list of -ms-* pseudo-elements at
https://msdn.microsoft.com/en-us/library/windows/apps/hh767361.aspx