### PR TITLE
Add background-attachment to SMACSS property sort order

### DIFF
--- a/data/property-sort-orders/smacss.txt
+++ b/data/property-sort-orders/smacss.txt
@@ -97,6 +97,7 @@ outline-width
 # Background
 
 background
+background-attachment
 background-color
 background-image
 background-repeat


### PR DESCRIPTION
Nothing too special just added a `background-attachment` to SMACSS list of properties for a `property_sort_order` linter.