### PR TITLE
Added initial to list of ignored for VariableForProperty;

### DIFF
--- a/lib/scss_lint/linter/variable_for_property.rb
+++ b/lib/scss_lint/linter/variable_for_property.rb
@@ -3,7 +3,7 @@ module SCSSLint
   class Linter::VariableForProperty < Linter
     include LinterRegistry
 
-    IGNORED_VALUES = %w[currentColor inherit transparent]
+    IGNORED_VALUES = %w[currentColor inherit initial transparent]
 
     def visit_root(_node)
       @properties = Set.new(config['properties'])


### PR DESCRIPTION
Added `initial` to list of ignored values for VariableForProperty as it is a CSS keyword in the vein of `inherit` and `transparent`, which are already ignored.