### PR TITLE
Add initial varforprop

### DIFF
--- a/lib/scss_lint/linter/variable_for_property.rb
+++ b/lib/scss_lint/linter/variable_for_property.rb
@@ -3,7 +3,7 @@ module SCSSLint
   class Linter::VariableForProperty < Linter
     include LinterRegistry
 
-    IGNORED_VALUES = %w[currentColor inherit transparent]
+    IGNORED_VALUES = %w[currentColor inherit initial transparent]
 
     def visit_root(_node)
       @properties = Set.new(config['properties'])

--- a/spec/scss_lint/linter/variable_for_property_spec.rb
+++ b/spec/scss_lint/linter/variable_for_property_spec.rb
@@ -118,6 +118,16 @@ describe SCSSLint::Linter::VariableForProperty do
       it { should_not report_lint }
     end
 
+    context 'when property specifies `initial`' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: initial;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
     context 'when property specifies `transparent`' do
       let(:scss) { <<-SCSS }
         p {


### PR DESCRIPTION
Added `initial` to list of ignored values for VariableForProperty as it is a CSS keyword in the vein of `inherit` and `transparent`, which are already ignored.