### PR TITLE
Add Webkit-specific pseudo elements to PseudoElement

### DIFF
--- a/data/pseudo-elements.txt
+++ b/data/pseudo-elements.txt
@@ -73,7 +73,9 @@
 -webkit-scrollbar-track
 -webkit-scrollbar-track-piece
 -webkit-search-cancel-button
+-webkit-search-decoration
 -webkit-search-results-button
+-webkit-search-results-decoration
 -webkit-slider-runnable-track
 -webkit-slider-thumb
 -webkit-textfield-decoration-container


### PR DESCRIPTION
There appears to be two additional pseudo elements for Webkit-based browsers.

- `::-webkit-search-decoration`
- `::-webkit-search-results-decoration`

[Reference](https://davidwalsh.name/remove-search-box-buttons-webkit)