### PR TITLE
Add Ruby 2.3 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
   - jruby-19mode
 
 before_script:


### PR DESCRIPTION
Ruby 2.3.0 was recently released and we want to make sure that our tests
are working under this version.