### PR TITLE
Add -webkit-full-page-media to pseudo-elements list

### DIFF
--- a/data/pseudo-elements.txt
+++ b/data/pseudo-elements.txt
@@ -54,6 +54,7 @@
 -webkit-datetime-edit-text
 -webkit-datetime-edit-year-field
 -webkit-file-upload-button
+-webkit-full-page-media
 -webkit-inner-spin-button
 -webkit-input-placeholder
 -webkit-keygen-select


### PR DESCRIPTION
References:
* http://browserbu.gs/css-hacks/webkit-full-page-media/
* http://browserstrangeness.bitbucket.org/css_hacks.html#safari
* https://gist.github.com/afabbro/3759334

I need this for https://github.com/twbs/bootstrap/pull/18816