### PR TITLE
Add -webkit-search-decoration to list of pseudo elements

### DIFF
--- a/data/pseudo-elements.txt
+++ b/data/pseudo-elements.txt
@@ -73,6 +73,7 @@
 -webkit-scrollbar-track
 -webkit-scrollbar-track-piece
 -webkit-search-cancel-button
+-webkit-search-decoration
 -webkit-search-results-button
 -webkit-slider-runnable-track
 -webkit-slider-thumb


### PR DESCRIPTION
The absence of this element was showing a linting error, as it appears in normalise.css (https://github.com/necolas/normalize.css/blob/master/normalize.css#L367)