### PR TITLE
SMACSS sort order for transition and transform

### DIFF
--- a/data/property-sort-orders/smacss.txt
+++ b/data/property-sort-orders/smacss.txt
@@ -55,7 +55,15 @@ column-count
 column-width
 
 transform
+transform-box
+transform-origin
+transform-style
+
 transition
+transition-delay
+transition-duration
+transition-property
+transition-timing-function
 
 # Border
 


### PR DESCRIPTION
Added missing sort order entries for indivdual properties for transition and transform.