### PR TITLE
Add backdrop-filter to properties.txt

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -17,6 +17,7 @@ animation-timing-function
 app-region
 appearance
 aspect-ratio
+backdrop-filter
 backface-visibility
 background
 background-attachment


### PR DESCRIPTION
The backdrop-filter property is unrecognized, although it is currently
supported by WebKit, is being added to Chromium, and has an open bug to
implement it in Firefox.

Draft Spec: https://drafts.fxtf.org/filters-2/#BackdropFilterProperty
Mozilla Doc: https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
Chromium: https://code.google.com/p/chromium/issues/detail?id=497522
Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1178765
WebKit: https://webkit.org/blog/3632/introducing-backdrop-filters/

Fixes #686