### PR TITLE
Add outline props to recess

### DIFF
--- a/data/property-sort-orders/recess.txt
+++ b/data/property-sort-orders/recess.txt
@@ -121,6 +121,9 @@ content
 quotes
 outline
 outline-offset
+outline-width
+outline-style
+outline-color
 opacity
 filter
 visibility


### PR DESCRIPTION
Currently throws errors for `outline-style`, `outline-color` and `outline-width` unless `ignore_unspecified` is enabled. This adds them to the specified props for recess.