### PR TITLE
Enable universal newline when reading scss files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `outline-{color,style,width}` properties to `recess` sort order list
 * Fix `TrailingSemicolon` to not report false positives for single line
   list/map literals
+* Improve compatibility with files that use CRLF and CR for newlines.
 
 ## 0.44.0
 

--- a/lib/scss_lint/engine.rb
+++ b/lib/scss_lint/engine.rb
@@ -24,8 +24,12 @@ module SCSSLint
       end
 
       # Need to force encoding to avoid Windows-related bugs.
+      # Need to encode with universal newline to avoid other Windows-related bugs.
       # Need `to_a` for Ruby 1.9.3.
-      @lines = @contents.force_encoding('UTF-8').lines.to_a
+      encoding = 'UTF-8'
+      @lines = @contents.force_encoding(encoding)
+                        .encode(encoding, universal_newline: true)
+                        .lines.to_a
       @tree = @engine.to_tree
       find_any_control_commands
     rescue Encoding::UndefinedConversionError, Sass::SyntaxError, ArgumentError => error

--- a/spec/scss_lint/linter/indentation_spec.rb
+++ b/spec/scss_lint/linter/indentation_spec.rb
@@ -19,6 +19,11 @@ describe SCSSLint::Linter::Indentation do
     SCSS
 
     it { should_not report_lint }
+
+    context 'with windows-style newlines with carriage returns' do
+      let(:scss) { 'p {  margin: 0;}' }
+      it { should_not report_lint }
+    end
   end
 
   context 'when lines in a rule set are not properly indented' do
@@ -33,6 +38,13 @@ describe SCSSLint::Linter::Indentation do
     it { should report_lint line: 2 }
     it { should_not report_lint line: 3 }
     it { should report_lint line: 4 }
+
+    context 'with windows-style newlines with carriage returns' do
+      let(:scss) { 'p {   margin: 0;}' }
+      it { should_not report_lint line: 1 }
+      it { should report_lint line: 2 }
+      it { should_not report_lint line: 3 }
+    end
   end
 
   context 'when selector of a nested rule set is not properly indented' do


### PR DESCRIPTION
SCSS-Lint seems to choke on a file that uses windows-style newlines with
carriage returns. (To type a windows-style newline with carriage return
in Vim, press `<Ctrl>+v<Ctrl>+m` in insert mode. This will show up as ^M.)

> SCSSLint::Linter::Indentation raised unexpected error linting file
> ./path/to/file.scss: 'undefined method `[]' for nil:NilClass'

To avoid this, we can encode the file contents using String#encode's
:universal_newline option, which

> Replaces CRLF (“rn”) and CR (“r”) with LF (“n”) if value is true.

http://ruby-doc.org/core-2.2.0/String.html#method-i-encode

I thought that maybe we wouldn't need the force_encoding anymore after
this change, but that was not the case since the test that was added
with that change started failing once I removed the force_encoding.

Fixes #700.