### PR TITLE
Loading plugins_directories relative to .scss-lint.yml file

### DIFF
--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -20,7 +20,7 @@ module SCSSLint
       def load(file, options = {})
         config_options = load_options_hash_from_file(file)
 
-        config = new(config_options)
+        config = new(config_options, file)
 
         # Need to call this before merging with the default configuration so
         # that plugins can override the default configuration while still being
@@ -201,11 +201,17 @@ module SCSSLint
       end
     end
 
-    def initialize(options)
+    def initialize(options, file = Config.user_file)
       @options = options
       @warnings = []
+      @file = file
 
       validate_linters
+    end
+
+    # returns the path of the config file
+    def file
+      @file
     end
 
     def [](key)

--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -8,7 +8,7 @@ module SCSSLint
     FILE_NAME = '.scss-lint.yml'.freeze
     DEFAULT_FILE = File.join(SCSS_LINT_HOME, 'config', 'default.yml')
 
-    attr_reader :options, :warnings
+    attr_reader :options, :warnings, :file
 
     class << self
       def default
@@ -207,11 +207,6 @@ module SCSSLint
       @file = file
 
       validate_linters
-    end
-
-    # returns the path of the config file
-    def file
-      @file
     end
 
     def [](key)

--- a/lib/scss_lint/plugins.rb
+++ b/lib/scss_lint/plugins.rb
@@ -26,7 +26,7 @@ module SCSSLint
 
     def plugin_directories
       Array(@config['plugin_directories']).map do |directory|
-        LinterDir.new(directory)
+        LinterDir.new(File.join(File.dirname(@config.file), directory))
       end
     end
   end

--- a/spec/scss_lint/plugins_spec.rb
+++ b/spec/scss_lint/plugins_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module SCSSLint
   describe Plugins do
-    let(:subject) { described_class.new(Config.new(config_options)) }
+    let(:subject) { described_class.new(Config.new(config_options, Config.user_file)) }
 
     describe '#load' do
       context 'when gem plugins are specified' do
@@ -22,9 +22,10 @@ module SCSSLint
       context 'when directory plugins are specified' do
         let(:config_options) { { 'plugin_directories' => ['some_dir'] } }
         let(:plugin) { double(load: nil) }
+        let(:plugin_dir) { File.join(File.dirname(Config.user_file), 'some_dir') }
 
         before do
-          Plugins::LinterDir.stub(:new).with('some_dir').and_return(plugin)
+          Plugins::LinterDir.stub(:new).with(plugin_dir).and_return(plugin)
         end
 
         it 'loads the plugin' do


### PR DESCRIPTION
Currently when the `scss-lint` command is run from outside the main project folder, it doesn't run the custom linter plugins specified in the `plugins_diretories` folder.

**Example:**

```
~/code/project/app/assets/stylesheets/
❯ scss-lint --show-linters --config=/Users/jonrohan/code/project/.scss-lint.yml 
Installed linters:
 ...
 - QualifyingElement
 - SelectorDepth
 - SelectorFormat
 - Shorthand
 - SingleLinePerProperty
 - SingleLinePerSelector
 ...


~/code/project/
❯ scss-lint --show-linters --config=/Users/jonrohan/code/project/.scss-lint.yml 
Installed linters:
 ...
 - QualifyingElement
 - SelectorDepth
 - SelectorFormat
 - SelectorJsPrefix
 - SelectorTagTargeting
 - Shorthand
 - SingleLinePerProperty
 - SingleLinePerSelector
 ...
```

* notice the custom linters `SelectorJsPrefix, SelectorTagTargeting`

**example .scss-lint.yml**

```
scss_files: "app/assets/stylesheets/**/*.scss"

plugin_directories:
  - 'test/fast/lib/scss-linters'

plugin_gems: []

# Default severity of all linters.
severity: error

linters:
  # Custom linters
  SelectorJsPrefix:
    enabled: true

  SelectorTagTargeting:
    enabled: true
```

This pull is an attempt to load the plugins directory from relative to the `.scss-lint.yml`. I believe this makes more sense because that's how `scss_files` behaves. 

I am willing to make any updates for code quality and or implementation to make this work. Thanks. :star2: 

-
cc @josh @sds @lencioni 