### PR TITLE
Visit children in SingleLinePerProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   list/map literals
 * Improve compatibility with files that use CRLF and CR for newlines.
 * Load `plugin_directories` relative to the config file itself
+* Fix bug in `SingleLinePerProperty` that prevented the linter from checking
+  nested selectors
 
 ## 0.44.0
 

--- a/lib/scss_lint/linter/single_line_per_property.rb
+++ b/lib/scss_lint/linter/single_line_per_property.rb
@@ -4,6 +4,8 @@ module SCSSLint
     include LinterRegistry
 
     def visit_rule(node)
+      yield # Continue linting children
+
       single_line = single_line_rule_set?(node)
       return if single_line && config['allow_single_line_rule_sets']
 

--- a/spec/scss_lint/linter/single_line_per_property_spec.rb
+++ b/spec/scss_lint/linter/single_line_per_property_spec.rb
@@ -70,4 +70,24 @@ describe SCSSLint::Linter::SingleLinePerProperty do
       it { should report_lint }
     end
   end
+
+  context 'when a nested single line rule set contains a single property' do
+    let(:scss) { <<-SCSS }
+      .my-selector {
+        p { color: #fff; }
+      }
+    SCSS
+
+    context 'and single line rule sets are allowed' do
+      let(:linter_config) { { 'allow_single_line_rule_sets' => true } }
+
+      it { should_not report_lint }
+    end
+
+    context 'and single line rule sets are not allowed' do
+      let(:linter_config) { { 'allow_single_line_rule_sets' => false } }
+
+      it { should report_lint }
+    end
+  end
 end


### PR DESCRIPTION
With the following configuration:

```yaml
SingleLinePerProperty:
  enabled: true
  allow_single_line_rule_sets: false
```

And the following SCSS:

```scss
.test { padding: 0; margin: 0; }
```

The SingleLinePerProperty correctly reports a lint here. However, if
this is nested:

```scss
.testing {
  .test { padding: 0; margin: 0; }
}
```

it is quiet.

It seems that the Sass parser is not visiting the child rule here. I
don't know enough about how this is supposed to work to know if that is
expected or not, but it seems that I can make this work by adding a line
that will recurse the children.

Fixes #709