### PR TITLE
Add SpaceAfterVariableColon linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Load `plugin_directories` relative to the config file itself
 * Fix bug in `SingleLinePerProperty` that prevented the linter from checking
   nested selectors
+* Add `SpaceAfterVariableColon` which checks for the spacing after a variable
+  colon
 
 ## 0.44.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -184,6 +184,10 @@ linters:
   SpaceAfterPropertyName:
     enabled: true
 
+  SpaceAfterVariableColon:
+    enabled: false
+    style: one_space # or 'no_space', 'at_least_one_space' or 'one_space_or_newline'
+
   SpaceAfterVariableName:
     enabled: true
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -44,6 +44,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [SpaceAfterComma](#spaceaftercomma)
 * [SpaceAfterPropertyColon](#spaceafterpropertycolon)
 * [SpaceAfterPropertyName](#spaceafterpropertyname)
+* [SpaceAfterVariableColon](#spaceaftervariablecolon)
 * [SpaceAfterVariableName](#spaceaftervariablename)
 * [SpaceAroundOperator](#spacearoundoperator)
 * [SpaceBeforeBrace](#spacebeforebrace)
@@ -1382,6 +1383,32 @@ margin : 0;
 ```scss
 margin: 0;
 ```
+
+## SpaceAfterVariableColon
+
+Variables should be formatted with a single space separating the colon from
+the variable's value.
+
+**Bad: no space after colon**
+```scss
+$my-color:#fff;
+```
+
+**Bad: more than one space after colon**
+```scss
+$my-color:  #fff;
+```
+
+**Good**
+```scss
+$my-color: #fff;
+```
+
+The `style` option allows you to specify a different preferred style.
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`style`              | `one_space`, `no_space`, `at_least_one_space` or `one_space_or_newline` (default **one_space**)
 
 ## SpaceAfterVariableName
 

--- a/lib/scss_lint/linter/space_after_variable_colon.rb
+++ b/lib/scss_lint/linter/space_after_variable_colon.rb
@@ -1,0 +1,62 @@
+module SCSSLint
+  # Checks for spaces following the colon that separates a variable's name from
+  # its value.
+  class Linter::SpaceAfterVariableColon < Linter
+    include LinterRegistry
+
+    def visit_variable(node)
+      whitespace = whitespace_after_colon(node)
+
+      case config['style']
+      when 'no_space'
+        check_for_no_spaces(node, whitespace)
+      when 'one_space'
+        check_for_one_space(node, whitespace)
+      when 'at_least_one_space'
+        check_for_at_least_one_space(node, whitespace)
+      when 'one_space_or_newline'
+        check_for_one_space_or_newline(node, whitespace)
+      end
+    end
+
+  private
+
+    def check_for_no_spaces(node, whitespace)
+      return if whitespace == []
+      add_lint(node, 'Colon after variable should not be followed by any spaces')
+    end
+
+    def check_for_one_space(node, whitespace)
+      return if whitespace == [' ']
+      add_lint(node, 'Colon after variable should be followed by one space')
+    end
+
+    def check_for_at_least_one_space(node, whitespace)
+      return if whitespace.uniq == [' ']
+      add_lint(node, 'Colon after variable should be followed by at least one space')
+    end
+
+    def check_for_one_space_or_newline(node, whitespace)
+      return if whitespace == [' '] || whitespace == ["\n"]
+      return if whitespace[0] == "\n" && whitespace[1..-1].uniq == [' ']
+      add_lint(node, 'Colon after variable should be followed by one space or a newline')
+    end
+
+    def whitespace_after_colon(node)
+      whitespace = []
+      offset = 0
+      start_pos = node.source_range.start_pos
+
+      # Find the colon after the variable name
+      offset = offset_to(start_pos, ':', offset) + 1
+
+      # Count spaces after the colon
+      while [' ', "\t", "\n"].include? character_at(start_pos, offset)
+        whitespace << character_at(start_pos, offset)
+        offset += 1
+      end
+
+      whitespace
+    end
+  end
+end

--- a/spec/scss_lint/linter/space_after_variable_colon_spec.rb
+++ b/spec/scss_lint/linter/space_after_variable_colon_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::SpaceAfterVariableColon do
+  let(:linter_config) { { 'style' => style } }
+
+  context 'when one space is preferred' do
+    let(:style) { 'one_space' }
+
+    context 'when the colon after a variable is not followed by space' do
+      let(:scss) { '$my-color:#fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a variable is followed by more than one space' do
+      let(:scss) { '$my-color:  #fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a variable is followed by a space' do
+      let(:scss) { '$my-color: #fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is surrounded by spaces' do
+      let(:scss) { '$my-color : #fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is followed by a space and a newline' do
+      let(:scss) { <<-SCSS }
+        $my-color:\s
+        #fff;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a property is followed by a tab' do
+      let(:scss) { <<-SCSS }
+        $my-color:\t#fff;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when no spaces are allowed' do
+    let(:style) { 'no_space' }
+
+    context 'when the colon after a variable is not followed by space' do
+      let(:scss) { '$my-color:#fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when colon after variable is not followed by space and the semicolon is missing' do
+      let(:scss) { '$my-color:#fff' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is followed by a space' do
+      let(:scss) { '$my-color: #fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a property is surrounded by spaces' do
+      let(:scss) { '$my-color : #fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a property is followed by multiple spaces' do
+      let(:scss) { '$my-color:  #fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a property is followed by a newline' do
+      let(:scss) { <<-SCSS }
+        $my-color:
+        #fff;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a property is followed by a tab' do
+      let(:scss) { <<-SCSS }
+        $my-color:\t#fff;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when at least one space is preferred' do
+    let(:style) { 'at_least_one_space' }
+
+    context 'when the colon after a variable is not followed by space' do
+      let(:scss) { '$my-color:#fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when colon after variable is not followed by space and the semicolon is missing' do
+      let(:scss) { '$my-color:#fff' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a variable is followed by a space' do
+      let(:scss) { '$my-color: #fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is surrounded by spaces' do
+      let(:scss) { '$my-color : #fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is followed by multiple spaces' do
+      let(:scss) { '$my-color:  #fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is followed by multiple spaces and a tab' do
+      let(:scss) { <<-SCSS }
+        $my-color:  \t#fff;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when one space or newline is preferred' do
+    let(:style) { 'one_space_or_newline' }
+
+    context 'when the colon after a variabl is not followed by space' do
+      let(:scss) { '$my-color:#fff;' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when the colon after a variable is followed by a space' do
+      let(:scss) { '$my-color: #fff;' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is followed by a newline and spaces' do
+      let(:scss) { <<-SCSS }
+        $my-color:
+              #fff;
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is followed by a newline and no spaces' do
+      let(:scss) { <<-SCSS }
+        $my-color:
+#fff;
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a variable is followed by a space and then a newline' do
+      let(:scss) { <<-SCSS }
+        $my-color:\s
+#fff;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+end


### PR DESCRIPTION
This adds the `SpaceAfterVariableColon` linter which checks
for spaces following the colon that separates a variable's
name from its value.

https://github.com/brigade/scss-lint/issues/445