### PR TITLE
Relax rake dependency version to allow >= 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   nested selectors
 * Add `SpaceAfterVariableColon` which checks for the spacing after a variable
   colon
+* Relax rake dependency version to allow >= 0.9
 
 ## 0.44.0
 

--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'rake', '~> 10.0'
+  s.add_dependency 'rake', '>= 0.9', '< 11'
   s.add_dependency 'sass', '~> 3.4.15'
 
   s.add_development_dependency 'rspec', '~> 3.4.0'


### PR DESCRIPTION
I am working in a project that is running an old version of rake, and
for historical reasons, it is going to be very difficult to upgrade to
rake 10. I tried looking into why this was set at rake 10 and I didn't
really come up with much, so I am relaxing this version requirement a
little.

I tried this out locally and specs pass on 0.9.* but not on 0.8.*, so
that seems like a good place to draw the line.