### PR TITLE
Improve BorderZero lint description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Add `SpaceAfterVariableColon` which checks for the spacing after a variable
   colon
 * Relax rake dependency version to allow >= 0.9
+* Improve `BorderZero` by adding the offending border property to the lint
+  description
 
 ## 0.44.0
 

--- a/lib/scss_lint/linter/border_zero.rb
+++ b/lib/scss_lint/linter/border_zero.rb
@@ -23,17 +23,17 @@ module SCSSLint
 
     def visit_prop(node)
       return unless BORDER_PROPERTIES.include?(node.name.first.to_s)
-      check_border(node, node.value.to_sass.strip)
+      check_border(node, node.name.first.to_s, node.value.to_sass.strip)
     end
 
   private
 
-    def check_border(node, border)
-      return unless %w[0 none].include?(border)
-      return if @preference[0] == border
+    def check_border(node, border_property, border_value)
+      return unless %w[0 none].include?(border_value)
+      return if @preference[0] == border_value
 
-      add_lint(node, "`border: #{@preference[0]}` is preferred over " \
-                     "`border: #{@preference[1]}`")
+      add_lint(node, "`#{border_property}: #{@preference[0]}` is preferred over " \
+                     "`#{border_property}: #{@preference[1]}`")
     end
   end
 end

--- a/spec/scss_lint/linter/border_zero_spec.rb
+++ b/spec/scss_lint/linter/border_zero_spec.rb
@@ -11,6 +11,8 @@ describe SCSSLint::Linter::BorderZero do
   end
 
   context 'when a property' do
+    let(:lint_description) { subject.lints.first.description }
+
     context 'contains a normal border' do
       let(:scss) { <<-SCSS }
         p {
@@ -39,6 +41,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border property in the description' do
+        lint_description.should == '`border: 0` is preferred over `border: none`'
+      end
     end
 
     context 'has a border-top of none' do
@@ -49,6 +55,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-top property in the description' do
+        lint_description.should == '`border-top: 0` is preferred over `border-top: none`'
+      end
     end
 
     context 'has a border-right of none' do
@@ -59,6 +69,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-right property in the description' do
+        lint_description.should == '`border-right: 0` is preferred over `border-right: none`'
+      end
     end
 
     context 'has a border-bottom of none' do
@@ -69,6 +83,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-bottom property in the description' do
+        lint_description.should == '`border-bottom: 0` is preferred over `border-bottom: none`'
+      end
     end
 
     context 'has a border-left of none' do
@@ -79,6 +97,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-left property in the description' do
+        lint_description.should == '`border-left: 0` is preferred over `border-left: none`'
+      end
     end
   end
 


### PR DESCRIPTION
This change updates the `BorderZero` linter
by adding the offending border property to
the lint description.

Fixes https://github.com/brigade/scss-lint/issues/708