### PR TITLE
Configure to not lint DuplicateProperty on consecutive lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SCSS-Lint Changelog
 
-## master (unreleased)
+## 0.45.0
 
 * Add `outline-{color,style,width}` properties to `recess` sort order list
 * Fix `TrailingSemicolon` to not report false positives for single line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SCSS-Lint Changelog
 
+## master (unreleased)
+
+* Add `ignore_consecutive` option to the `DuplicateProperty` linter, allowing
+  duplicate consecutive properties. It accepts `true`, `false`, or a list of
+  property names to be ignored.
+
 ## 0.45.0
 
 * Add `outline-{color,style,width}` properties to `recess` sort order list
@@ -12,6 +18,8 @@
 * Add `SpaceAfterVariableColon` which checks for the spacing after a variable
   colon
 * Relax rake dependency version to allow >= 0.9
+* Improve `BorderZero` by adding the offending border property to the lint
+  description
 
 ## 0.44.0
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -348,13 +348,22 @@ function, so the intention is to fall back to the color `#fff`.
 }
 ```
 
-In this situation, using duplicate properties is acceptable, but the linter
-won't be able to deduce your intention, and will still report an error.
+In this situation, using duplicate properties is acceptable, but you will have
+to configure DuplicateProperty with the `ignore_consecutive` option, so that it
+won't consider such cases to be lint. `ignore_consecutive` can be set to `true`,
+`false` (default), or a list of property names to be allowed. For example, to
+ignore consecutive `background` and `transition` properties, as above, you can
+configure DuplicateProperty with:
 
-If you've made the decision to _not_ support older browsers, then this lint is
-more helpful since you don't want to clutter your CSS with fallbacks.
-Otherwise, you may want to consider disabling this check in your
-`.scss-lint.yml` configuration.
+```yaml
+DuplicateProperty:
+  ignore_consecutive:
+    - background
+    - transition
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`ignore_consecutive` | Whether to ignore consecutive duplicate properties (default **false**), or a whitelist.
 
 ## ElsePlacement
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -360,6 +360,7 @@ DuplicateProperty:
   ignore_consecutive:
     - background
     - transition
+```
 
 Configuration Option | Description
 ---------------------|---------------------------------------------------------

--- a/lib/scss_lint/linter/border_zero.rb
+++ b/lib/scss_lint/linter/border_zero.rb
@@ -23,17 +23,17 @@ module SCSSLint
 
     def visit_prop(node)
       return unless BORDER_PROPERTIES.include?(node.name.first.to_s)
-      check_border(node, node.value.to_sass.strip)
+      check_border(node, node.name.first.to_s, node.value.to_sass.strip)
     end
 
   private
 
-    def check_border(node, border)
-      return unless %w[0 none].include?(border)
-      return if @preference[0] == border
+    def check_border(node, border_property, border_value)
+      return unless %w[0 none].include?(border_value)
+      return if @preference[0] == border_value
 
-      add_lint(node, "`border: #{@preference[0]}` is preferred over " \
-                     "`border: #{@preference[1]}`")
+      add_lint(node, "`#{border_property}: #{@preference[0]}` is preferred over " \
+                     "`#{border_property}: #{@preference[1]}`")
     end
   end
 end

--- a/lib/scss_lint/version.rb
+++ b/lib/scss_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module SCSSLint
-  VERSION = '0.44.0'.freeze
+  VERSION = '0.45.0'.freeze
 end

--- a/spec/scss_lint/linter/border_zero_spec.rb
+++ b/spec/scss_lint/linter/border_zero_spec.rb
@@ -11,6 +11,8 @@ describe SCSSLint::Linter::BorderZero do
   end
 
   context 'when a property' do
+    let(:lint_description) { subject.lints.first.description }
+
     context 'contains a normal border' do
       let(:scss) { <<-SCSS }
         p {
@@ -39,6 +41,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border property in the description' do
+        lint_description.should == '`border: 0` is preferred over `border: none`'
+      end
     end
 
     context 'has a border-top of none' do
@@ -49,6 +55,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-top property in the description' do
+        lint_description.should == '`border-top: 0` is preferred over `border-top: none`'
+      end
     end
 
     context 'has a border-right of none' do
@@ -59,6 +69,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-right property in the description' do
+        lint_description.should == '`border-right: 0` is preferred over `border-right: none`'
+      end
     end
 
     context 'has a border-bottom of none' do
@@ -69,6 +83,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-bottom property in the description' do
+        lint_description.should == '`border-bottom: 0` is preferred over `border-bottom: none`'
+      end
     end
 
     context 'has a border-left of none' do
@@ -79,6 +97,10 @@ describe SCSSLint::Linter::BorderZero do
       SCSS
 
       it { should report_lint line: 2 }
+
+      it 'should report lint with the border-left property in the description' do
+        lint_description.should == '`border-left: 0` is preferred over `border-left: none`'
+      end
     end
   end
 

--- a/spec/scss_lint/linter/duplicate_property_spec.rb
+++ b/spec/scss_lint/linter/duplicate_property_spec.rb
@@ -186,4 +186,59 @@ describe SCSSLint::Linter::DuplicateProperty do
 
     it { should report_lint line: 4 }
   end
+
+  context 'when consecutive duplicate properties are allowed' do
+    let(:linter_config) { { 'ignore_consecutive' => true } }
+
+    context 'when rule set contains consecutive duplicates' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-color: #fff;
+          background-color: rgba(255, 255, 255, 0.7);
+          background-color: a-third-thing;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when rule set contains non-consecutive duplicates' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0;
+          padding: 0;
+          margin: 1em;
+        }
+      SCSS
+
+      it { should report_lint line: 4 }
+    end
+  end
+
+  context 'when specific consecutive duplicate properties are allowed' do
+    let(:linter_config) { { 'ignore_consecutive' => ['background-color', 'transition'] } }
+
+    context 'when rule set contains consecutive duplicates in whitelist' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-color: #fff;
+          background-color: rgba(255, 255, 255, 0.7);
+          background-color: a-third-thing;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when rule set contains consecutive duplicates not in whitelist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0;
+          margin: 5px;
+        }
+      SCSS
+
+      it { should report_lint line: 3 }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #715. CC #114.

Explanation added to README.