### PR TITLE
Add PrivateNamingConvention linter

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,10 +1,12 @@
 {
   "lib/scss_lint/*.rb": {
     "alternate": "spec/scss_lint/{}_spec.rb",
-    "type": "source"
+    "type": "source",
+    "dispatch": "rspec spec/scss_lint/{}_spec.rb"
   },
   "spec/scss_lint/*_spec.rb": {
     "alternate": "lib/scss_lint/{}.rb",
-    "type": "test"
+    "type": "test",
+    "dispatch": "rspec {file}"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add `ignore_consecutive` option to the `DuplicateProperty` linter, allowing
   duplicate consecutive properties. It accepts `true`, `false`, or a list of
   property names to be ignored.
+* Add `PrivateNamingConvention` linter which enforces that functions, mixins,
+  and variables that follow the private naming convention (default to
+  underscore-prefixed) are defined and used within the same file
 
 ## 0.45.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -116,6 +116,10 @@ linters:
   PlaceholderInExtend:
     enabled: true
 
+  PrivateNamingConvention:
+    enabled: false
+    prefix: _
+
   PropertyCount:
     enabled: false
     include_nested: false

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -31,6 +31,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [NameFormat](#nameformat)
 * [NestingDepth](#nestingdepth)
 * [PlaceholderInExtend](#placeholderinextend)
+* [PrivateNamingConvention](#privatenamingconvention)
 * [PropertyCount](#propertycount)
 * [PropertySortOrder](#propertysortorder)
 * [PropertySpelling](#propertyspelling)
@@ -769,7 +770,9 @@ refer to it using the hyphenated form instead.
 Depending on whether you use underscores to denote private functions within your
 code, you can set the `allow_leading_underscore` option (enabled by default)
 which will ignore leading underscores in names if they exist, allowing
-declarations like `@function _private-function() { ... }`.
+declarations like `@function _private-function() { ... }`. If you want to
+further enforce a private naming convention, use
+[PrivateNamingConvention](#privatenamingconvention).
 
 Configuration Option            | Description
 --------------------------------|----------------------------------------------
@@ -866,6 +869,52 @@ See [Mastering Sass extends and placeholders](http://8gramgorilla.com/mastering-
 
 If you want to prevent the use of the `@extend` directive entirely, see the
 [ExtendDirective](#extenddirective) linter.
+
+## PrivateNamingConvention
+
+**Disabled by default**
+
+Enforces that functions, mixins, and variables that follow the private naming
+convention (default to underscore-prefixed, e.g. `$_foo`) are defined and used
+within the same file.
+
+**Bad**
+```scss
+$_foo: #f00;
+
+p {
+  color: #00f;
+}
+```
+
+**Bad**
+```scss
+p {
+  color: $_foo;
+}
+```
+
+**Bad**
+```scss
+p {
+  color: $_foo;
+}
+
+$_foo: #f00;
+```
+
+**Good**
+```scss
+$_foo: #f00;
+
+p {
+  color: $_foo;
+}
+```
+
+Configuration Option | Description
+---------------------|----------------------------------------------
+`prefix`             | Prefix used to denote "private" (default `_`)
 
 ## PropertyCount
 

--- a/lib/scss_lint/linter/private_naming_convention.rb
+++ b/lib/scss_lint/linter/private_naming_convention.rb
@@ -1,0 +1,86 @@
+module SCSSLint
+  # Verifies that variables, functions, and mixins that follow the private naming convention are
+  # defined and used within the same file.
+  class Linter::PrivateNamingConvention < Linter
+    include LinterRegistry
+
+    def visit_root(node)
+      # Register all top-level function, mixin, and variable definitions.
+      node.children.each_with_object([]) do |child_node|
+        if child_node.is_a?(Sass::Tree::FunctionNode)
+          register_node child_node, 'function'
+        elsif child_node.is_a?(Sass::Tree::MixinDefNode)
+          register_node child_node, 'mixin'
+        elsif child_node.is_a?(Sass::Tree::VariableNode)
+          register_node child_node, 'variable'
+        else
+          yield
+        end
+      end
+
+      # After we have visited everything, we want to see if any private things
+      # were defined but not used.
+      after_visit_all
+    end
+
+    def visit_script_funcall(node)
+      check_privacy(node, 'function')
+      yield # Continue linting any arguments of this function call
+    end
+
+    def visit_mixin(node)
+      check_privacy(node, 'mixin')
+      yield # Continue into content block of this mixin's block
+    end
+
+    def visit_script_variable(node)
+      check_privacy(node, 'variable')
+    end
+
+  private
+
+    def register_node(node, node_type, node_text = node.name)
+      return unless private?(node)
+
+      @private_definitions ||= {}
+      @private_definitions[node_type] ||= {}
+
+      @private_definitions[node_type][node_text] = {
+        node: node,
+        times_used: 0,
+      }
+    end
+
+    def check_privacy(node, node_type, node_text = node.name)
+      return unless private?(node)
+
+      if @private_definitions &&
+          @private_definitions[node_type] &&
+          @private_definitions[node_type][node_text]
+        @private_definitions[node_type][node_text][:times_used] += 1
+        return
+      end
+
+      add_lint(
+        node, "Private #{node_type} #{node_text} must be defined in the same file it is used")
+    end
+
+    def private?(node)
+      node.name.start_with?(config['prefix'])
+    end
+
+    def after_visit_all
+      return unless @private_definitions
+
+      @private_definitions.each do |node_type, nodes|
+        nodes.each do |node_text, node_info|
+          next if node_info[:times_used] > 0
+          add_lint(
+            node_info[:node],
+            "Private #{node_type} #{node_text} must be used in the same file it is defined"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/scss_lint/linter/private_naming_convention_spec.rb
+++ b/spec/scss_lint/linter/private_naming_convention_spec.rb
@@ -1,0 +1,261 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::PrivateNamingConvention do
+  context 'when a private variable' do
+    context 'is not used in the same file it is defined' do
+      let(:scss) { <<-SCSS }
+        $_foo: red;
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'is used but not defined in the same file' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: $_foo;
+          background: rgba($_foo, 0);
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+      it { should report_lint line: 3 }
+    end
+
+    context 'is used but has not been defined quite yet' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: $_foo;
+          background: rgba($_foo, 0);
+        }
+
+        $_foo: red;
+      SCSS
+
+      it { should report_lint line: 2 }
+      it { should report_lint line: 3 }
+    end
+
+    context 'is defined and used in the same file' do
+      let(:scss) { <<-SCSS }
+        $_foo: red;
+
+        p {
+          color: $_foo;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined and used in the same file in a function' do
+      let(:scss) { <<-SCSS }
+        $_foo: red;
+
+        p {
+          color: rgba($_foo, 0);
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and not used' do
+      let(:scss) { <<-SCSS }
+        p {
+          $_foo: red;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when a public variable' do
+    context 'is used but not defined' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: $foo;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined but not used' do
+      let(:scss) { <<-SCSS }
+        $foo: red;
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when a private mixin' do
+    context 'is not used in the same file it is defined' do
+      let(:scss) { <<-SCSS }
+        @mixin _foo {
+          color: red;
+        }
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'is used but not defined in the same file' do
+      let(:scss) { <<-SCSS }
+        p {
+          @include _foo;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is used but has not been defined quite yet' do
+      let(:scss) { <<-SCSS }
+        p {
+          @include _foo;
+        }
+
+        @mixin _foo {
+          color: red;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is defined within a selector and not used' do
+      let(:scss) { <<-SCSS }
+        p {
+          @mixin _foo {
+            color: red;
+          }
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined and used in the same file' do
+      let(:scss) { <<-SCSS }
+        @mixin _foo {
+          color: red;
+        }
+
+        p {
+          @include _foo;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when a public mixin' do
+    context 'is used but not defined' do
+      let(:scss) { <<-SCSS }
+        p {
+          @include foo;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined but not used' do
+      let(:scss) { <<-SCSS }
+        @mixin foo {
+          color: red;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  describe 'when a private function' do
+    context 'is not used in the same file it is defined' do
+      let(:scss) { <<-SCSS }
+        @function _foo() {
+          @return red;
+        }
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'is used but not defined in the same file' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: _foo();
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is used but has not been defined quite yet' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: _foo();
+        }
+
+        @function _foo() {
+          @return red;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is defined within a selector and not used' do
+      let(:scss) { <<-SCSS }
+        p {
+          @function _foo() {
+            @return red;
+          }
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined and used in the same file' do
+      let(:scss) { <<-SCSS }
+        @function _foo() {
+          @return red;
+        }
+
+        p {
+          color: _foo();
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when a public function' do
+    context 'is used but not defined' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: foo();
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined but not used' do
+      let(:scss) { <<-SCSS }
+        @function foo() {
+          @return red;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+  end
+end


### PR DESCRIPTION
Although the `NameFormat` linter has an option to allow for leading
underscores, it does not enforce the convention. It would be really
great to either have a linter that does this.

What I mean by enforcing privacy for the leading underscore convention
is, for variables, functions, and mixins that start with a leading
underscore, we should verify that:

- any definitions are used within the same file
- any uses are defined within the same file
- any uses are preceded by their definitions

I considered adding this to `NameFormat`, but it seems specialized
enough that I decided to put it in its own linter. I left the prefix
configurable but defaulting to `_`, which is likely what most people
would use anyway.

Fixes #721