### PR TITLE
Configure to not lint DuplicateProperty on consecutive lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SCSS-Lint Changelog
 
+## master (unreleased)
+
+* Add `ignore_consecutive` option to the `DuplicateProperty` linter, allowing
+  duplicate consecutive properties. It accepts `true`, `false`, or a list of
+  property names to be ignored.
+
 ## 0.45.0
 
 * Add `outline-{color,style,width}` properties to `recess` sort order list

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -348,13 +348,23 @@ function, so the intention is to fall back to the color `#fff`.
 }
 ```
 
-In this situation, using duplicate properties is acceptable, but the linter
-won't be able to deduce your intention, and will still report an error.
+In this situation, using duplicate properties is acceptable, but you will have
+to configure DuplicateProperty with the `ignore_consecutive` option, so that it
+won't consider such cases to be lint. `ignore_consecutive` can be set to `true`,
+`false` (default), or a list of property names to be allowed. For example, to
+ignore consecutive `background` and `transition` properties, as above, you can
+configure DuplicateProperty with:
 
-If you've made the decision to _not_ support older browsers, then this lint is
-more helpful since you don't want to clutter your CSS with fallbacks.
-Otherwise, you may want to consider disabling this check in your
-`.scss-lint.yml` configuration.
+```yaml
+DuplicateProperty:
+  ignore_consecutive:
+    - background
+    - transition
+```
+
+Configuration Option | Description
+---------------------|---------------------------------------------------------
+`ignore_consecutive` | Whether to ignore consecutive duplicate properties (default **false**), or a whitelist.
 
 ## ElsePlacement
 

--- a/spec/scss_lint/linter/duplicate_property_spec.rb
+++ b/spec/scss_lint/linter/duplicate_property_spec.rb
@@ -186,4 +186,59 @@ describe SCSSLint::Linter::DuplicateProperty do
 
     it { should report_lint line: 4 }
   end
+
+  context 'when consecutive duplicate properties are allowed' do
+    let(:linter_config) { { 'ignore_consecutive' => true } }
+
+    context 'when rule set contains consecutive duplicates' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-color: #fff;
+          background-color: rgba(255, 255, 255, 0.7);
+          background-color: a-third-thing;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when rule set contains non-consecutive duplicates' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0;
+          padding: 0;
+          margin: 1em;
+        }
+      SCSS
+
+      it { should report_lint line: 4 }
+    end
+  end
+
+  context 'when specific consecutive duplicate properties are allowed' do
+    let(:linter_config) { { 'ignore_consecutive' => ['background-color', 'transition'] } }
+
+    context 'when rule set contains consecutive duplicates in whitelist' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-color: #fff;
+          background-color: rgba(255, 255, 255, 0.7);
+          background-color: a-third-thing;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when rule set contains consecutive duplicates not in whitelist' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0;
+          margin: 5px;
+        }
+      SCSS
+
+      it { should report_lint line: 3 }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #715. CC #114.

This includes a whitelist concept. The new `ignore_consecutive` option can be
specified with a list.