### PR TITLE
Fix locally failing LinterGem spec

### DIFF
--- a/spec/scss_lint/plugins/linter_gem_spec.rb
+++ b/spec/scss_lint/plugins/linter_gem_spec.rb
@@ -10,6 +10,7 @@ module SCSSLint
       let(:config_file_exists) { false }
 
       before do
+        File.stub(:exist?).and_call_original
         File.stub(:exist?).with(config_file).and_return(config_file_exists)
       end
 


### PR DESCRIPTION
This spec was failing locally for me because File.exist? was being
called with unexpected arguments, and we had stubbed it but not allowed
these unexpected arguments. I fixed this by just having it call through
to the original in this case.