### PR TITLE
Improve nested private names in PrivateNamingConvention

### DIFF
--- a/lib/scss_lint/linter/private_naming_convention.rb
+++ b/lib/scss_lint/linter/private_naming_convention.rb
@@ -7,11 +7,12 @@ module SCSSLint
     def visit_root(node)
       # Register all top-level function, mixin, and variable definitions.
       node.children.each_with_object([]) do |child_node|
-        if child_node.is_a?(Sass::Tree::FunctionNode)
+        case child_node
+        when Sass::Tree::FunctionNode
           register_node child_node, 'function'
-        elsif child_node.is_a?(Sass::Tree::MixinDefNode)
+        when Sass::Tree::MixinDefNode
           register_node child_node, 'mixin'
-        elsif child_node.is_a?(Sass::Tree::VariableNode)
+        when Sass::Tree::VariableNode
           register_node child_node, 'variable'
         else
           yield

--- a/lib/scss_lint/linter/private_naming_convention.rb
+++ b/lib/scss_lint/linter/private_naming_convention.rb
@@ -4,16 +4,17 @@ module SCSSLint
   class Linter::PrivateNamingConvention < Linter
     include LinterRegistry
 
+    DEFINING_CLASSES = [
+      Sass::Tree::FunctionNode,
+      Sass::Tree::MixinDefNode,
+      Sass::Tree::VariableNode,
+    ].freeze
+
     def visit_root(node)
       # Register all top-level function, mixin, and variable definitions.
       node.children.each_with_object([]) do |child_node|
-        case child_node
-        when Sass::Tree::FunctionNode
-          register_node child_node, 'function'
-        when Sass::Tree::MixinDefNode
-          register_node child_node, 'mixin'
-        when Sass::Tree::VariableNode
-          register_node child_node, 'variable'
+        if DEFINING_CLASSES.include?(child_node.class)
+          register_node child_node
         else
           yield
         end
@@ -25,43 +26,44 @@ module SCSSLint
     end
 
     def visit_script_funcall(node)
-      check_privacy(node, 'function')
+      check_privacy(node, Sass::Tree::FunctionNode)
       yield # Continue linting any arguments of this function call
     end
 
     def visit_mixin(node)
-      check_privacy(node, 'mixin')
+      check_privacy(node, Sass::Tree::MixinDefNode)
       yield # Continue into content block of this mixin's block
     end
 
     def visit_script_variable(node)
-      check_privacy(node, 'variable')
+      check_privacy(node, Sass::Tree::VariableNode)
     end
 
   private
 
-    def register_node(node, node_type, node_text = node.name)
+    def register_node(node, node_text = node.name)
       return unless private?(node)
 
       @private_definitions ||= {}
-      @private_definitions[node_type] ||= {}
+      @private_definitions[node.class.name] ||= {}
 
-      @private_definitions[node_type][node_text] = {
+      @private_definitions[node.class.name][node_text] = {
         node: node,
         times_used: 0,
       }
     end
 
-    def check_privacy(node, node_type, node_text = node.name)
+    def check_privacy(node, defining_node_class, node_text = node.name)
       return unless private?(node)
 
       if @private_definitions &&
-          @private_definitions[node_type] &&
-          @private_definitions[node_type][node_text]
-        @private_definitions[node_type][node_text][:times_used] += 1
+          @private_definitions[defining_node_class.name] &&
+          @private_definitions[defining_node_class.name][node_text]
+        @private_definitions[defining_node_class.name][node_text][:times_used] += 1
         return
       end
 
+      node_type = humanize_node_class(node)
       add_lint(
         node, "Private #{node_type} #{node_text} must be defined in the same file it is used")
     end
@@ -76,11 +78,23 @@ module SCSSLint
       @private_definitions.each do |node_type, nodes|
         nodes.each do |node_text, node_info|
           next if node_info[:times_used] > 0
+          node_type = humanize_node_class(node_info[:node])
           add_lint(
             node_info[:node],
             "Private #{node_type} #{node_text} must be used in the same file it is defined"
           )
         end
+      end
+    end
+
+    def humanize_node_class(node)
+      case node
+      when Sass::Tree::FunctionNode
+        'function'
+      when Sass::Tree::MixinDefNode
+        'mixin'
+      when Sass::Tree::VariableNode
+        'variable'
       end
     end
   end

--- a/spec/scss_lint/linter/private_naming_convention_spec.rb
+++ b/spec/scss_lint/linter/private_naming_convention_spec.rb
@@ -69,6 +69,70 @@ describe SCSSLint::Linter::PrivateNamingConvention do
 
       it { should_not report_lint }
     end
+
+    context 'is defined within a selector and used' do
+      let(:scss) { <<-SCSS }
+        p {
+          $_foo: red;
+          color: $_foo;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used in a nested selector' do
+      let(:scss) { <<-SCSS }
+        p {
+          $_foo: red;
+
+          a {
+            color: $_foo;
+          }
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector but too late' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: $_foo;
+          $_foo: red;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is defined within a selector but after the nested selector it is used in' do
+      let(:scss) { <<-SCSS }
+        p {
+          a {
+            color: $_foo;
+          }
+
+          $_foo: red;
+        }
+      SCSS
+
+      it { should report_lint line: 3 }
+    end
+
+    context 'is defined in a different selector than it is used in' do
+      let(:scss) { <<-SCSS }
+        p {
+          $_foo: red;
+        }
+
+        a {
+          color: $_foo;
+        }
+      SCSS
+
+      it { should report_lint line: 6 }
+    end
   end
 
   context 'when a public variable' do
@@ -136,6 +200,66 @@ describe SCSSLint::Linter::PrivateNamingConvention do
       SCSS
 
       it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used within that selector' do
+      let(:scss) { <<-SCSS }
+        p {
+          @mixin _foo {
+            color: red;
+          }
+
+          @include _foo;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used within a nested selector' do
+      let(:scss) { <<-SCSS }
+        p {
+          @mixin _foo {
+            color: red;
+          }
+
+          a {
+            @include _foo;
+          }
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used within that selector too early' do
+      let(:scss) { <<-SCSS }
+        p {
+          @include _foo;
+
+          @mixin _foo {
+            color: red;
+          }
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is defined within a selector and used within a nested selector too early' do
+      let(:scss) { <<-SCSS }
+        p {
+          a {
+            @include _foo;
+          }
+
+          @mixin _foo {
+            color: red;
+          }
+        }
+      SCSS
+
+      it { should report_lint line: 3 }
     end
 
     context 'is defined and used in the same file' do
@@ -220,6 +344,66 @@ describe SCSSLint::Linter::PrivateNamingConvention do
       SCSS
 
       it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used within the same selector' do
+      let(:scss) { <<-SCSS }
+        p {
+          @function _foo() {
+            @return red;
+          }
+
+          color: _foo();
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used within a nested selector' do
+      let(:scss) { <<-SCSS }
+        p {
+          @function _foo() {
+            @return red;
+          }
+
+          a {
+            color: _foo();
+          }
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'is defined within a selector and used within the same selector too early' do
+      let(:scss) { <<-SCSS }
+        p {
+          color: _foo();
+
+          @function _foo() {
+            @return red;
+          }
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'is defined within a selector and used within a nested too early' do
+      let(:scss) { <<-SCSS }
+        p {
+          a {
+            color: _foo();
+          }
+
+          @function _foo() {
+            @return red;
+          }
+        }
+      SCSS
+
+      it { should report_lint line: 3 }
     end
 
     context 'is defined and used in the same file' do


### PR DESCRIPTION
I was thinking about this rule and realized an edge case that I had
forgotten to account for. What happens if you have a nested private
variable? This wasn't handled very well, but this commit improves it.