### PR TITLE
Add a preprocess_command option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ it into your [SCM hooks](https://github.com/brigade/overcommit).
 * [Exit Status Codes](#exit-status-codes)
 * [Linters](#linters)
 * [Custom Linters](#custom-linters)
+* [Preprocessing](#preprocessing)
 * [Editor Integration](#editor-integration)
 * [Git Integration](#git-integration)
 * [Rake Integration](#rake-integration)
@@ -412,6 +413,29 @@ gem 'scss_lint_plugin_example', git: 'git://github.com/cih/scss_lint_plugin_exam
 
 As long as you execute `scss-lint` via `bundle exec scss-lint`, it should be
 able to load the gem.
+
+## Preprocessing
+
+Sometimes SCSS files need to be preprocessed before being linted. This is made
+possible with two options that can be specified in your configuration file.
+
+The `preprocess_command` option specifies the command to run once per SCSS
+file. The command can be specified with arguments. The contents of a SCSS
+file will be written to STDIN, and the processed SCSS contents must be written
+to STDOUT. If the process exits with a code other than 0, scss-lint will
+immediately exit with an error.
+
+For example, `preprocess_command: "cat"` specifies a simple no-op preprocessor
+(on Unix-like systems). `cat` simply writes the contents of STDIN back out to
+STDOUT. To preprocess SCSS files with
+[Jekyll front matter](http://jekyllrb.com/docs/assets/), you can use
+`preprocess_command: "sed '1,2s/---//'"`. This will strip out any Jekyll front
+matter, but preserve line numbers.
+
+If only some SCSS files need to be preprocessed, you may use the
+`preprocess_files` option to specify a list of file globs that need
+preprocessing. Preprocessing only a subset of files should make scss-lint more
+performant.
 
 ## Editor Integration
 

--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -18,6 +18,7 @@ module SCSSLint
       config:         78, # Configuration error
       no_files:       80, # No files matched by specified glob patterns
       plugin:         82, # Plugin loading error
+      preprocessor:   84, # Preprocessor error
     }.freeze
 
     # Create a CLI that outputs to the specified logger.
@@ -106,6 +107,9 @@ module SCSSLint
       when NoSuchLinter
         log.error exception.message
         halt :usage
+      when SCSSLint::Exceptions::PreprocessorError
+        log.error exception.message
+        halt :preprocessor
       else
         config_file = relevant_configuration_file(options) if options
 

--- a/lib/scss_lint/engine.rb
+++ b/lib/scss_lint/engine.rb
@@ -1,5 +1,7 @@
 require 'sass'
 
+require 'open3'
+
 module SCSSLint
   class FileEncodingError < StandardError; end
 
@@ -15,13 +17,14 @@ module SCSSLint
     #
     # @param options [Hash]
     # @option options [String] :file The file to load
+    # @option options [String] :path The path of the file to load
     # @option options [String] :code The code to parse
+    # @option options [String] :preprocess_command A preprocessing command
+    # @option options [List<String>] :preprocess_files A list of files that should be preprocessed
     def initialize(options = {})
-      if options[:path]
-        build_from_file(options)
-      elsif options[:code]
-        build_from_string(options[:code])
-      end
+      @preprocess_command = options[:preprocess_command]
+      @preprocess_files = options[:preprocess_files]
+      build(options)
 
       # Need to force encoding to avoid Windows-related bugs.
       # Need to encode with universal newline to avoid other Windows-related bugs.
@@ -45,6 +48,14 @@ module SCSSLint
 
   private
 
+    def build(options)
+      if options[:path]
+        build_from_file(options)
+      elsif options[:code]
+        build_from_string(options[:code])
+      end
+    end
+
     # @param options [Hash]
     # @option file [IO] if provided, us this as the file object
     # @option path [String] path of file, loading from this if `file` object not
@@ -52,18 +63,30 @@ module SCSSLint
     def build_from_file(options)
       @filename = options[:path]
       @contents = options[:file] ? options[:file].read : File.read(@filename)
+      preprocess_contents
       @engine = Sass::Engine.new(@contents, ENGINE_OPTIONS.merge(filename: @filename))
     end
 
     # @param scss [String]
     def build_from_string(scss)
-      @engine = Sass::Engine.new(scss, ENGINE_OPTIONS)
       @contents = scss
+      preprocess_contents
+      @engine = Sass::Engine.new(@contents, ENGINE_OPTIONS)
     end
 
     def find_any_control_commands
       @any_control_commands =
         @lines.any? { |line| line['scss-lint:disable'] || line['scss-line:enable'] }
+    end
+
+    def preprocess_contents # rubocop:disable CyclomaticComplexity
+      return unless @preprocess_command
+      # Never preprocess :code scss if @preprocess_files is specified.
+      return if @preprocess_files && @filename.nil?
+      return if @preprocess_files &&
+                @preprocess_files.none? { |pattern| File.fnmatch(pattern, @filename) }
+      @contents, status = Open3.capture2(@preprocess_command, stdin_data: @contents)
+      raise SCSSLint::Exceptions::PreprocessorError if status != 0
     end
   end
 end

--- a/lib/scss_lint/exceptions.rb
+++ b/lib/scss_lint/exceptions.rb
@@ -17,4 +17,7 @@ module SCSSLint::Exceptions
 
   # Raised when a linter gem plugin is required but not installed.
   class PluginGemLoadError < StandardError; end
+
+  # Raised when the preprocessor tool exits with a non-zero code.
+  class PreprocessorError < StandardError; end
 end

--- a/lib/scss_lint/runner.rb
+++ b/lib/scss_lint/runner.rb
@@ -25,8 +25,10 @@ module SCSSLint
     # @param file [Hash]
     # @option file [String] File object
     # @option path [String] path to File (determines which Linter config to apply)
-    def find_lints(file)
-      engine = Engine.new(file)
+    def find_lints(file) # rubocop:disable AbcSize
+      options = file.merge(preprocess_command: @config.options['preprocess_command'],
+                           preprocess_files: @config.options['preprocess_files'])
+      engine = Engine.new(options)
 
       @linters.each do |linter|
         begin

--- a/spec/scss_lint/preprocess_spec.rb
+++ b/spec/scss_lint/preprocess_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe SCSSLint::Engine do
+  let(:engine) { described_class.new(options) }
+  let(:command) { 'my-command' }
+  let(:scss) { <<-SCSS }
+    ---
+    ---
+    $red: #f00;
+  SCSS
+  let(:processed) { <<-SCSS }
+    $red: #f00;
+  SCSS
+
+  context 'preprocess_command is specified' do
+    let(:options) { { code: scss, preprocess_command: command } }
+
+    it 'preprocesses, and Sass is able to parse' do
+      open3 = class_double('Open3').as_stubbed_const
+      open3.should_receive(:capture2).with(command, stdin_data: scss).and_return([processed, 0])
+
+      variable = engine.tree.children[0]
+      expect(variable).to be_instance_of(Sass::Tree::VariableNode)
+      expect(variable.name).to eq('red')
+    end
+  end
+
+  context 'preprocessor fails' do
+    let(:options) { { code: scss, preprocess_command: command } }
+
+    it 'preprocesses, and Sass is able to parse' do
+      open3 = class_double('Open3').as_stubbed_const
+      open3.should_receive(:capture2).with(command, stdin_data: scss).and_return([processed, 1])
+
+      expect { engine }.to raise_error(SCSSLint::Exceptions::PreprocessorError)
+    end
+  end
+
+  context 'both preprocess_command and preprocess_files are specified' do
+    let(:path) { 'foo/a.scss' }
+
+    context 'file should be preprocessed' do
+      let(:options) do
+        { path: path,
+          preprocess_command: command,
+          preprocess_files: ['foo/*.scss'] }
+      end
+
+      it 'preprocesses, and Sass is able to parse' do
+        open3 = class_double('Open3').as_stubbed_const
+        open3.should_receive(:capture2).with(command, stdin_data: scss).and_return([processed, 0])
+        File.should_receive(:read).with(path).and_return(scss)
+
+        variable = engine.tree.children[0]
+        expect(variable).to be_instance_of(Sass::Tree::VariableNode)
+        expect(variable.name).to eq('red')
+      end
+    end
+
+    context 'file should not be preprocessed' do
+      let(:options) do
+        { path: path,
+          preprocess_command: command,
+          preprocess_files: ['bar/*.scss'] }
+      end
+
+      it 'does not preprocess, and Sass throws' do
+        File.should_receive(:read).with(path).and_return(scss)
+        expect { engine }.to raise_error(Sass::SyntaxError)
+      end
+    end
+
+    context 'code should never be preprocessed' do
+      let(:options) do
+        { code: scss,
+          preprocess_command: command,
+          preprocess_files: ['foo/*.scss'] }
+      end
+
+      it 'does not preprocess, and Sass throws' do
+        expect { engine }.to raise_error(Sass::SyntaxError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #689 

Annoying that this fix is for such a trivial issue. But possibly preprocessors give lots of power to users? See the README changes for a description of the new `preprocess_command` and `preprocess_files` options.

Here's a list of design decisions that you may particularly want to review:

* I added a top-level section to the README, because it's pretty big.
* I made a new PreprocessorError, which will cause scss-lint to exit with a new code, 84.
* I essentially doubled the number of options that `SCSSLint::Engine` takes, which I feel bad about. Like a slippery slope kind of thing. Let me know if that interface should be refactored.