### PR TITLE
Fix bug with TAP reporter using file hashes as filenames

### DIFF
--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -182,7 +182,7 @@ module SCSSLint
 
     # @param options [Hash]
     # @param lints [Array<Lint>]
-    # @param files [Array<String>]
+    # @param files [Array<Hash>]
     def report_lints(options, lints, files)
       sorted_lints = lints.sort_by { |l| [l.filename, l.location] }
       options.fetch(:reporters).each do |reporter, output|

--- a/lib/scss_lint/reporter.rb
+++ b/lib/scss_lint/reporter.rb
@@ -8,7 +8,7 @@ module SCSSLint
     end
 
     # @param lints [List<Lint>] a list of Lints sorted by file and line number
-    # @param files [List<String>] a list of the files that were linted
+    # @param files [List<Hash>] a list of the files that were linted
     # @param logger [SCSSLint::Logger]
     def initialize(lints, files, logger)
       @lints = lints

--- a/lib/scss_lint/reporter/tap_reporter.rb
+++ b/lib/scss_lint/reporter/tap_reporter.rb
@@ -14,7 +14,7 @@ module SCSSLint
 
   private
 
-    # @param files [Array<String>]
+    # @param files [Array<Hash>]
     # @param lints [Array<SCSSLint::Lint>]
     # @return [String]
     def format_plan(files, lints)
@@ -24,15 +24,15 @@ module SCSSLint
       "1..#{files.count + extra_lines}#{comment}"
     end
 
-    # @param files [Array<String>]
+    # @param files [Array<Hash>]
     # @param lints [Array<SCSSLint::Lint>]
     # @return [Array<String>] one item per ok file or not ok lint
     def format_files(files, lints)
       unless lints.any?
         # There are no lints, so we can take a shortcut and just output an ok
         # test line for every file.
-        return files.map.with_index do |filename, index|
-          format_ok(filename, index + 1)
+        return files.map.with_index do |file, index|
+          format_ok(file, index + 1)
         end
       end
 
@@ -45,17 +45,17 @@ module SCSSLint
       grouped_lints = group_lints_by_filename(lints)
 
       test_number = 1
-      files.map do |filename|
-        if grouped_lints.key?(filename)
+      files.map do |file|
+        if grouped_lints.key?(file[:path])
           # This file has lints, so we want to generate a "not ok" test line for
           # each failing lint.
-          grouped_lints[filename].map do |lint|
+          grouped_lints[file[:path]].map do |lint|
             formatted = format_not_ok(lint, test_number)
             test_number += 1
             formatted
           end
         else
-          formatted = format_ok(filename, test_number)
+          formatted = format_ok(file, test_number)
           test_number += 1
           [formatted]
         end
@@ -73,11 +73,11 @@ module SCSSLint
       grouped_lints
     end
 
-    # @param filename [String]
+    # @param file [Hash]
     # @param test_number [Number]
     # @return [String]
-    def format_ok(filename, test_number)
-      "ok #{test_number} - #{filename}"
+    def format_ok(file, test_number)
+      "ok #{test_number} - #{file[:path]}"
     end
 
     # @param lint [SCSSLint::Lint]

--- a/lib/scss_lint/reporter/tap_reporter.rb
+++ b/lib/scss_lint/reporter/tap_reporter.rb
@@ -86,16 +86,25 @@ module SCSSLint
     def format_not_ok(lint, test_number)
       location = lint.location
       test_line_description = "#{lint.filename}:#{location.line}:#{location.column}"
-      test_line_description += " #{lint.linter.name}" if lint.linter
+
+      data = {
+        'message' => lint.description,
+        'severity' => lint.severity.to_s,
+        'file' => lint.filename,
+        'line' => lint.location.line,
+        'column' => lint.location.column,
+      }
+
+      if lint.linter
+        test_line_description += " #{lint.linter.name}" if lint.linter
+        data['name'] = lint.linter.name
+      end
+
+      data_yaml = data.to_yaml.strip.gsub(/^/, '  ')
 
       <<-EOS.strip
 not ok #{test_number} - #{test_line_description}
-  ---
-  message: #{lint.description}
-  severity: #{lint.severity}
-  file: #{lint.filename}
-  line: #{lint.location.line}
-  column: #{lint.location.column}
+#{data_yaml}
   ...
       EOS
     end

--- a/lib/scss_lint/reporter/tap_reporter.rb
+++ b/lib/scss_lint/reporter/tap_reporter.rb
@@ -93,10 +93,9 @@ not ok #{test_number} - #{test_line_description}
   ---
   message: #{lint.description}
   severity: #{lint.severity}
-  data:
-    file: #{lint.filename}
-    line: #{lint.location.line}
-    column: #{lint.location.column}
+  file: #{lint.filename}
+  line: #{lint.location.line}
+  column: #{lint.location.column}
   ...
       EOS
     end

--- a/spec/scss_lint/reporter/tap_reporter_spec.rb
+++ b/spec/scss_lint/reporter/tap_reporter_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe SCSSLint::Reporter::TAPReporter do
   let(:logger) { SCSSLint::Logger.new($stdout) }
-  subject { described_class.new(lints, filenames, logger) }
+  let(:files) { filenames.map { |filename| { path: filename } } }
+  subject { described_class.new(lints, files, logger) }
 
   describe '#report_lints' do
     context 'when there are no files' do

--- a/spec/scss_lint/reporter/tap_reporter_spec.rb
+++ b/spec/scss_lint/reporter/tap_reporter_spec.rb
@@ -67,28 +67,25 @@ not ok 2 - not-ok1.scss:123:10 SCSSLint::Linter::PrivateNamingConvention
   ---
   message: Description of lint 1
   severity: warning
-  data:
-    file: not-ok1.scss
-    line: 123
-    column: 10
+  file: not-ok1.scss
+  line: 123
+  column: 10
   ...
 not ok 3 - not-ok2.scss:20:2 SCSSLint::Linter::PrivateNamingConvention
   ---
   message: Description of lint 2
   severity: error
-  data:
-    file: not-ok2.scss
-    line: 20
-    column: 2
+  file: not-ok2.scss
+  line: 20
+  column: 2
   ...
 not ok 4 - not-ok2.scss:21:3 SCSSLint::Linter::PrivateNamingConvention
   ---
   message: Description of lint 3
   severity: warning
-  data:
-    file: not-ok2.scss
-    line: 21
-    column: 3
+  file: not-ok2.scss
+  line: 21
+  column: 3
   ...
 ok 5 - ok2.scss
         EOS

--- a/spec/scss_lint/reporter/tap_reporter_spec.rb
+++ b/spec/scss_lint/reporter/tap_reporter_spec.rb
@@ -70,6 +70,7 @@ not ok 2 - not-ok1.scss:123:10 SCSSLint::Linter::PrivateNamingConvention
   file: not-ok1.scss
   line: 123
   column: 10
+  name: SCSSLint::Linter::PrivateNamingConvention
   ...
 not ok 3 - not-ok2.scss:20:2 SCSSLint::Linter::PrivateNamingConvention
   ---
@@ -78,6 +79,7 @@ not ok 3 - not-ok2.scss:20:2 SCSSLint::Linter::PrivateNamingConvention
   file: not-ok2.scss
   line: 20
   column: 2
+  name: SCSSLint::Linter::PrivateNamingConvention
   ...
 not ok 4 - not-ok2.scss:21:3 SCSSLint::Linter::PrivateNamingConvention
   ---
@@ -86,6 +88,7 @@ not ok 4 - not-ok2.scss:21:3 SCSSLint::Linter::PrivateNamingConvention
   file: not-ok2.scss
   line: 21
   column: 3
+  name: SCSSLint::Linter::PrivateNamingConvention
   ...
 ok 5 - ok2.scss
         EOS


### PR DESCRIPTION
When I wrote this reporter, I assumed that the `files` was an array of
strings (partly because that is how it was documented). However, in
practice, it is an array of hashes, so this didn't work correctly.