### PR TITLE
Add linear-gradient() to NameFormat whitelist.

### DIFF
--- a/lib/scss_lint/linter/name_format.rb
+++ b/lib/scss_lint/linter/name_format.rb
@@ -39,6 +39,7 @@ module SCSSLint
       scaleX scaleY scaleZ
       skewX skewY
       translateX translateY translateZ
+      linear-gradient
     ].to_set
 
     def check_name(node, node_type, node_text = node.name)

--- a/spec/scss_lint/linter/name_format_spec.rb
+++ b/spec/scss_lint/linter/name_format_spec.rb
@@ -163,6 +163,16 @@ describe SCSSLint::Linter::NameFormat do
       it { should_not report_lint }
     end
 
+    context 'when using whitelisted css function' do
+      let(:scss) { <<-SCSS }
+        .gradient {
+          background: linear-gradient(#000, #fff);
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
     context 'when a mixin contains keyword arguments with underscores' do
       let(:scss) { '@include mixin($some_var: 4);' }
 


### PR DESCRIPTION
This change adds the CSS function `linear-gradient()` to the NameFormat whitelist. Since it's not a Sass function it shouldn't be throwing a lint warning.