### PR TITLE
Also test on JRuby 9000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ rvm:
   - 2.2
   - 2.3.0
   - jruby-19mode
+  - jruby-9.0.5.0
 
 before_script:
   - git config --local user.email "travis@travis.ci"


### PR DESCRIPTION
Because JRuby is compatible with Ruby 2.2.x and Sass will be [dropping ruby 1.9.3 support](http://blog.sass-lang.com/posts/560719)