### PR TITLE
Feature/stdout total numbers of errors

### DIFF
--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -191,6 +191,7 @@ module SCSSLint
 
         if output == :stdout
           log.log results
+          log.error "Total errors: #{sorted_lints.count}"
         else
           File.new(output, 'w+').print results
         end

--- a/lib/scss_lint/version.rb
+++ b/lib/scss_lint/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module SCSSLint
-  VERSION = '0.48.0'.freeze
+  VERSION = '0.48.1'.freeze
 end

--- a/spec/scss_lint/cli_spec.rb
+++ b/spec/scss_lint/cli_spec.rb
@@ -158,6 +158,11 @@ describe SCSSLint::CLI do
         safe_run
         output.should include 'Some description'
       end
+
+      it 'shows total number of errors' do
+        safe_run
+        output.should include 'Total errors: 1'
+      end
     end
 
     context 'when the runner raises an error' do


### PR DESCRIPTION
It would be nice to have a total number of errors/warnings after each run:
![screen shot 2016-04-26 at 22 24 13](https://cloud.githubusercontent.com/assets/618900/14831297/c4fcbdda-0bfd-11e6-9d70-467166130f42.png)
