### PR TITLE
Linter `UnnecessaryParentReference` catch non-immediate child

### DIFF
--- a/lib/scss_lint/linter/unnecessary_parent_reference.rb
+++ b/lib/scss_lint/linter/unnecessary_parent_reference.rb
@@ -18,7 +18,13 @@ module SCSSLint
       # element {
       #   &.foo {}
       # }
-      return if sequence.members.first.members.size > 1
+      #
+      # or
+      #
+      # element {
+      #   & .foo {}
+      # }
+      return sequence=~/(^&([ ]{1})?\..+$)|(^\..+([ ]{1})&$)/
 
       # Allow sequences that contain multiple parent references, e.g.
       # element {

--- a/spec/scss_lint/linter/unnecessary_parent_reference_spec.rb
+++ b/spec/scss_lint/linter/unnecessary_parent_reference_spec.rb
@@ -31,6 +31,16 @@ describe SCSSLint::Linter::UnnecessaryParentReference do
     it { should_not report_lint }
   end
 
+  context 'when an amperand is chained with class' do
+    let(:scss) { <<-SCSS }
+      p {
+        & .foo {}
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
   context 'when an amperand follows a direct descendant operator' do
     let(:scss) { <<-SCSS }
       p {


### PR DESCRIPTION
Currently linter `UnnecessaryParentReference` misses the use case of non-immediate child selectors.

This PR allows both of the following cases:
```js
      p {
        & .foo {}
      }

      p {
        &.foo {}
      }