### PR TITLE
Wrap at-declaratives in backticks

### DIFF
--- a/lib/scss_lint/linter/debug_statement.rb
+++ b/lib/scss_lint/linter/debug_statement.rb
@@ -4,7 +4,7 @@ module SCSSLint
     include LinterRegistry
 
     def visit_debug(node)
-      add_lint(node, 'Remove @debug line')
+      add_lint(node, 'Remove `@debug` line')
     end
   end
 end

--- a/lib/scss_lint/linter/else_placement.rb
+++ b/lib/scss_lint/linter/else_placement.rb
@@ -36,10 +36,10 @@ module SCSSLint
       if same_line_preferred?
         unless curly_on_same_line
           add_lint(else_node,
-                   '@else should be placed on same line as previous curly brace')
+                   '`@else` should be placed on same line as previous curly brace')
         end
       elsif curly_on_same_line
-        add_lint(else_node, '@else should be placed on its own line')
+        add_lint(else_node, '`@else` should be placed on its own line')
       end
     end
 

--- a/lib/scss_lint/linter/extend_directive.rb
+++ b/lib/scss_lint/linter/extend_directive.rb
@@ -4,7 +4,7 @@ module SCSSLint
     include LinterRegistry
 
     def visit_extend(node)
-      add_lint(node, 'Do not use the @extend directive (@include a @mixin ' \
+      add_lint(node, 'Do not use the `@extend` directive (`@include` a `@mixin` ' \
                      'instead)')
     end
   end


### PR DESCRIPTION
We, at thoughtbot, use `scss-lint` to check for style violations in
[Hound]. Hound will comment on style violations on an open PR,
and leave comments on the violating lines.

To avoid pinging GitHub users in the comment we can wrap the
declaratives in backticks.

This was done prior in https://github.com/brigade/scss-lint/pull/354

[Hound]: https://houndci.com/