### PR TITLE
Feature: Trailing comma in maps

### DIFF
--- a/lib/scss_lint/linter/trailing_comma_in_map.rb
+++ b/lib/scss_lint/linter/trailing_comma_in_map.rb
@@ -1,0 +1,4 @@
+module SCSSLint
+  class Linter::TrailingCommaInMap < Linter
+  end
+end

--- a/spec/scss_lint/linter/compass/trailing_comma_in_map_spec.rb
+++ b/spec/scss_lint/linter/compass/trailing_comma_in_map_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::TrailingCommaInMap do
+  let(:linter_config) { { 'present' => present } }
+
+  context 'when trailing comma is preferred' do
+    let(:present) { true }
+
+    context 'when the file is empty' do
+      let(:scss) { '' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the map is a single line' do
+      let(:scss) do
+        <<-SCSS
+          $map: (key_one: value_one);
+        SCSS
+      end
+
+      it { should_not report_lint }
+    end
+
+    context 'when the last line in a multi-line map ends with a comma' do
+      let(:scss) do
+        <<-SCSS
+          $map: (
+            key_one: value_one,
+            key_two: value_two,
+          );
+        SCSS
+      end
+
+      it { should_not report_lint }
+    end
+
+    context 'when the last line in a multi-line map does not end with a comma' do
+      let(:scss) do
+        <<-SCSS
+          $map: (
+            key_one: value_one,
+            key_two: value_two,
+          );
+        SCSS
+      end
+
+      it { should report_lint }
+    end
+  end
+
+  context 'when no trailing newline is preferred' do
+    let(:present) { false }
+
+    context 'when the file is empty' do
+      let(:scss) { '' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when the map is a single line' do
+      let(:scss) do
+        <<-SCSS
+          $map: (key_one: value_one);
+        SCSS
+      end
+
+      it { should_not report_lint }
+    end
+
+    context 'when the last line in a multi-line map ends with a comma' do
+      let(:scss) do
+        <<-SCSS
+          $map: (
+            key_one: value_one,
+            key_two: value_two,
+          );
+        SCSS
+      end
+
+      it { should report_lint }
+    end
+
+    context 'when the last line in a multi-line map does not end with a comma' do
+      let(:scss) do
+        <<-SCSS
+          $map: (
+            key_one: value_one,
+            key_two: value_two
+          );
+        SCSS
+      end
+
+      it { should_not report_lint }
+    end
+  end
+end


### PR DESCRIPTION
Closes [#815][815].

A trailing comma in maps make for cleaner diffs when adding to or
removing from the map.

**Bad:**

```scss
$map: (
  key_one: value_one,
  key_two: value_two
);
```

**Good:**

```scss
$map: (
  key_one: value_one,
  key_two: value_two,
);
```

[815]: https://github.com/brigade/scss-lint/issues/815