### PR TITLE
Fix linter_options to actually allow setting options

### DIFF
--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -270,9 +270,9 @@ module SCSSLint
     end
 
     def linter_options(linter)
-      { 'severity' => @options['severity'] }.merge(
-        @options['linters'].fetch(self.class.linter_name(linter), {})
-      )
+      options = @options['linters'].fetch(self.class.linter_name(linter), {})
+      options['severity'] ||= @options['severity']
+      options
     end
 
     def excluded_file?(file_path)


### PR DESCRIPTION
The way it's currently phrased, each time you call linter_options it
returns a new hash, because it's merging a hash literal with the
existing options. Thus you can never change the options.

Note: This doesn't take care of setting the value of
`@options['linters'][linter_name]` to the new hash if a new hash was
returned by fetch, but neither does the existing code so I'm not sure if
that's also desired.

This fixes #718 and potentially other issues with setting linter specific options.