### PR TITLE
Add SpaceAfterComment Linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix `--exclude-linter` flag
 * Modify `ColorKeyword` linter to allow color keywords to be used as arguments
   in `map-*`-related function calls
+* Add `SpaceAfterComment` which checks for spacing after comment literal
 
 ## 0.49.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -181,6 +181,11 @@ linters:
     enabled: true
     style: one_space # or 'no_space', or 'at_least_one_space'
 
+  SpaceAfterComment:
+    enabled: true
+    style: at_least_one_space # or 'no_space', or 'at_least_one_space'
+    allow_empty_comments: true
+
   SpaceAfterPropertyColon:
     enabled: true
     style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -45,6 +45,7 @@ Below is a list of linters supported by `scss-lint`, ordered alphabetically.
 * [SingleLinePerProperty](#singlelineperproperty)
 * [SingleLinePerSelector](#singlelineperselector)
 * [SpaceAfterComma](#spaceaftercomma)
+* [SpaceAfterComment](#spaceaftercomment)
 * [SpaceAfterPropertyColon](#spaceafterpropertycolon)
 * [SpaceAfterPropertyName](#spaceafterpropertyname)
 * [SpaceAfterVariableColon](#spaceaftervariablecolon)
@@ -1460,6 +1461,30 @@ Configuration Option | Description
 ---------------------|---------------------------------------------------------
 `style`              | `one_space`, or `no_space` or `at_least_one_space` (default **one_space**)
 
+## SpaceAfterComment
+
+Comment literals should be followed by a space.
+
+**Bad: no space after comment literal**
+```scss
+//no space
+/*no space*/
+/*!no space for loud comment*/
+```
+
+**Good: comment literals followed by a space**
+```scss
+// one space
+/* one space*/
+/*! one space for loud comment*/
+```
+
+The `style` option allows you to specify a different preferred style.
+
+Configuration Option   | Description
+-----------------------|---------------------------------------------------------
+`allow_empty_comments` | Allow empty comments for `//` style (default **true**)
+`style`                | `one_space`, or `no_space` or `at_least_one_space` (default **one_space**)
 
 ## SpaceAfterPropertyColon
 

--- a/lib/scss_lint/linter/space_after_comment.rb
+++ b/lib/scss_lint/linter/space_after_comment.rb
@@ -1,0 +1,69 @@
+module SCSSLint
+  # Checks for a space after comment literals
+  class Linter::SpaceAfterComment < Linter
+    include LinterRegistry
+
+    def visit_comment(node)
+      source = source_from_range(node.source_range).strip
+      check_method = "check_#{node.type}_comment"
+      send(check_method, node, source)
+    end
+
+  private
+
+    def check_silent_comment(node, source)
+      source.split("\n").each_with_index do |line, index|
+        next if config['allow_empty_comments'] && line.strip.length <= 2
+        whitespace = whitespace_after_comment(line, 2)
+        check_for_space(node.line + index, whitespace)
+      end
+    end
+
+    def check_normal_comment(node, source)
+      whitespace = whitespace_after_comment(source, 2)
+      check_for_space(node, whitespace)
+    end
+
+    def check_loud_comment(node, source)
+      whitespace = whitespace_after_comment(source, 3)
+      check_for_space(node, whitespace)
+    end
+
+    def check_for_no_spaces(node_or_line, whitespace)
+      return if whitespace == 0
+      add_lint(node_or_line, 'Comment literal should not be followed by any spaces')
+    end
+
+    def check_for_one_space(node_or_line, whitespace)
+      return if whitespace == 1
+      add_lint(node_or_line, 'Comment literal should be followed by one space')
+    end
+
+    def check_for_at_least_one_space(node_or_line, whitespace)
+      return if whitespace >= 1
+      add_lint(node_or_line, 'Comment literal should be followed by at least one space')
+    end
+
+    def check_for_space(node_or_line, spaces)
+      case config['style']
+      when 'one_space'
+        check_for_one_space(node_or_line, spaces)
+      when 'no_space'
+        check_for_no_spaces(node_or_line, spaces)
+      when 'at_least_one_space'
+        check_for_at_least_one_space(node_or_line, spaces)
+      end
+    end
+
+    def whitespace_after_comment(source, offset)
+      whitespace = 0
+
+      while [' ', "\t"].include? source[offset]
+        whitespace += 1
+        offset += 1
+      end
+
+      whitespace
+    end
+  end
+end

--- a/spec/scss_lint/linter/space_after_comment_spec.rb
+++ b/spec/scss_lint/linter/space_after_comment_spec.rb
@@ -1,0 +1,480 @@
+require 'spec_helper'
+
+describe SCSSLint::Linter::SpaceAfterComment do
+  context 'when no comments exist' do
+    let(:scss) { <<-SCSS }
+      p {
+        margin: 0;
+      }
+    SCSS
+
+    it { should_not report_lint }
+  end
+
+  context 'when one space is preferred' do
+    let(:linter_config) { { 'style' => 'one_space' } }
+
+    context 'when silent comment and no space' do
+      let(:scss) { <<-SCSS }
+        //no space
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when silent comment and one space' do
+      let(:scss) { <<-SCSS }
+        // one space
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when silent comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+        //   multiple spaces
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when inline silent comment and no space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; //no space
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when inline silent comment and one space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; // one space
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when inline silent comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; //   multiple spaces
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when multiple silent comments' do
+      let(:scss) { <<-SCSS }
+       //no space
+       // space
+       //no space
+       //   multiple spaces
+      SCSS
+
+      it { should report_lint line: 1 }
+      it { should_not report_lint line: 2 }
+      it { should report_lint line: 3 }
+      it { should report_lint line: 4 }
+    end
+
+    context 'when multiple silent comments and allow_empty_comments' do
+      let(:linter_config) { { 'style' => 'one_space', 'allow_empty_comments' => true } }
+      let(:scss) { <<-SCSS }
+       //
+       //no space
+       // space
+       //no space
+       //   multiple spaces
+      SCSS
+
+      it { should_not report_lint line: 1 }
+      it { should report_lint line: 2 }
+      it { should_not report_lint line: 3 }
+      it { should report_lint line: 4 }
+      it { should report_lint line: 5 }
+    end
+
+    context 'when normal comment and no space' do
+      let(:scss) { <<-SCSS }
+       /*no space */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when normal comment and one space' do
+      let(:scss) { <<-SCSS }
+       /* one space */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when normal comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+       /*   multiple spaces */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when inline normal comment and no space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /*no space */
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when inline normal comment and one space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /* one space */
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when inline normal comment and multiple space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /*   multiple spaces */
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when loud comment and no space' do
+      let(:scss) { <<-SCSS }
+       /*!no space */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when loud comment and one space' do
+      let(:scss) { <<-SCSS }
+       /*! one space */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when loud comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+       /*!   multiple spaces */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when no spaces are allowed' do
+    let(:linter_config) { { 'style' => 'no_space' } }
+
+    context 'when silent comment and no space' do
+      let(:scss) { <<-SCSS }
+        //no space
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when silent comment and one space' do
+      let(:scss) { <<-SCSS }
+        // one space
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when silent comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+        //   multiple spaces
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when inline silent comment and no space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; //no space
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when inline silent comment and one space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; // one space
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when inline silent comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; //   multiple spaces
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when multiple silent comments' do
+      let(:scss) { <<-SCSS }
+       //no space
+       // space
+       //no space
+       //   multiple spaces
+      SCSS
+
+      it { should_not report_lint line: 1 }
+      it { should report_lint line: 2 }
+      it { should_not report_lint line: 3 }
+      it { should report_lint line: 4 }
+    end
+
+    context 'when normal comment and no space' do
+      let(:scss) { <<-SCSS }
+       /*no space */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when normal comment and one space' do
+      let(:scss) { <<-SCSS }
+       /* one space */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when normal comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+       /*   multiple spaces */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when inline normal comment and no space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /*no space */
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when inline normal comment and one space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /* one space */
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when inline normal comment and multiple space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /*   multiple spaces */
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when loud comment and no space' do
+      let(:scss) { <<-SCSS }
+       /*!no space */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when loud comment and one space' do
+      let(:scss) { <<-SCSS }
+       /*! one space */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when loud comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+       /*!   multiple spaces */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+  end
+
+  context 'when at least one space is preferred' do
+    let(:linter_config) { { 'style' => 'at_least_one_space' } }
+
+    context 'when silent comment and no space' do
+      let(:scss) { <<-SCSS }
+        //no space
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when silent comment and one space' do
+      let(:scss) { <<-SCSS }
+        // one space
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when silent comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+        //   multiple spaces
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when inline silent comment and no space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; //no space
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when inline silent comment and one space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; // one space
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when inline silent comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; //   multiple spaces
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when multiple silent comments' do
+      let(:scss) { <<-SCSS }
+       //no space
+       // space
+       //no space
+       //   multiple spaces
+      SCSS
+
+      it { should report_lint line: 1 }
+      it { should_not report_lint line: 2 }
+      it { should report_lint line: 3 }
+      it { should_not report_lint line: 4 }
+    end
+
+    context 'when normal comment and no space' do
+      let(:scss) { <<-SCSS }
+       /*no space */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when normal comment and one space' do
+      let(:scss) { <<-SCSS }
+       /* one space */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when normal comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+       /*   multiple spaces */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when inline normal comment and no space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /*no space */
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when inline normal comment and one space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /* one space */
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when inline normal comment and multiple space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0; /*   multiple spaces */
+        }
+      SCSS
+
+      it { should_not report_lint line: 2 }
+    end
+
+    context 'when loud comment and no space' do
+      let(:scss) { <<-SCSS }
+       /*!no space */
+      SCSS
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'when loud comment and one space' do
+      let(:scss) { <<-SCSS }
+       /*! one space */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+
+    context 'when loud comment and multiple spaces' do
+      let(:scss) { <<-SCSS }
+       /*!   multiple spaces */
+      SCSS
+
+      it { should_not report_lint line: 1 }
+    end
+  end
+end


### PR DESCRIPTION
Adds a linter for #813.

This is a big PR (alot of it is tests) so definitely let me know what changes you would like to see in order to get this merged! (or if it should be merged at all). 

The basic idea is to look at comment nodes and depending on the type, we do different things. 
 - If it's `:silent`, we need to split by new lines since sass will combine consecutive comments `//` into one node. There is also an option to allow empty `//` comments.
 - If it's `:normal`, count the spaces after `/*`
 - If it's `:loud`, count the spaces after `/*!`