### PR TITLE
SpaceAfterComma linter fixes

### DIFF
--- a/lib/scss_lint/linter.rb
+++ b/lib/scss_lint/linter.rb
@@ -52,7 +52,8 @@ module SCSSLint
 
     # Helper for creating lint from a parse tree node
     #
-    # @param node_or_line_or_location [Sass::Script::Tree::Node, Fixnum, SCSSLint::Location]
+    # @param node_or_line_or_location [Sass::Script::Tree::Node, Fixnum,
+    #                                  SCSSLint::Location, Sass::Source::Position]
     # @param message [String]
     def add_lint(node_or_line_or_location, message)
       @lints << Lint.new(self,
@@ -165,6 +166,8 @@ module SCSSLint
     def extract_location(node_or_line_or_location)
       if node_or_line_or_location.is_a?(Location)
         node_or_line_or_location
+      elsif node_or_line_or_location.is_a?(Sass::Source::Position)
+        Location.new(node_or_line_or_location.line, node_or_line_or_location.offset)
       elsif node_or_line_or_location.respond_to?(:source_range) &&
             node_or_line_or_location.source_range
         location_from_range(node_or_line_or_location.source_range)

--- a/lib/scss_lint/linter/space_after_comma.rb
+++ b/lib/scss_lint/linter/space_after_comma.rb
@@ -89,7 +89,8 @@ module SCSSLint
         next if char == "\n" || # Ignore trailing spaces
                 valid_spaces_after_comma?(spaces)
 
-        add_lint comma_position, "Commas in #{arg_type} should be followed by a single space"
+        style_message = config['style'].tr('_', ' ')
+        add_lint comma_position, "Commas in #{arg_type} should be followed by #{style_message}"
       end
     end
 

--- a/spec/scss_lint/linter/space_after_comma_spec.rb
+++ b/spec/scss_lint/linter/space_after_comma_spec.rb
@@ -354,7 +354,7 @@ describe SCSSLint::Linter::SpaceAfterComma do
       }
       SCSS
 
-      it "is the correct column" do
+      it 'is the correct column' do
         subject.lints.first.location.column.should == 15
       end
     end
@@ -366,7 +366,7 @@ describe SCSSLint::Linter::SpaceAfterComma do
       }
       SCSS
 
-      it "specifies the style" do
+      it 'specifies the style' do
         subject.lints.first.description.should == 'Commas in lists should be followed by one space'
       end
     end
@@ -777,8 +777,9 @@ describe SCSSLint::Linter::SpaceAfterComma do
       }
       SCSS
 
-      it "specifies the style" do
-        subject.lints.first.description.should == 'Commas in lists should be followed by at least one space'
+      it 'specifies the style' do
+        subject.lints.first.description.should ==
+          'Commas in lists should be followed by at least one space'
       end
     end
   end
@@ -1122,7 +1123,7 @@ describe SCSSLint::Linter::SpaceAfterComma do
       }
       SCSS
 
-      it "specifies the style" do
+      it 'specifies the style' do
         subject.lints.first.description.should == 'Commas in lists should be followed by no space'
       end
     end

--- a/spec/scss_lint/linter/space_after_comma_spec.rb
+++ b/spec/scss_lint/linter/space_after_comma_spec.rb
@@ -346,6 +346,18 @@ describe SCSSLint::Linter::SpaceAfterComma do
 
       it { should report_lint line: 4 }
     end
+
+    context 'column number' do
+      let(:scss) { <<-SCSS }
+      p {
+        property: $a,$b;
+      }
+      SCSS
+
+      it "is the correct column" do
+        subject.lints.first.location.column.should == 15
+      end
+    end
   end
 
   context 'when more than one space is preferred' do

--- a/spec/scss_lint/linter/space_after_comma_spec.rb
+++ b/spec/scss_lint/linter/space_after_comma_spec.rb
@@ -358,6 +358,18 @@ describe SCSSLint::Linter::SpaceAfterComma do
         subject.lints.first.location.column.should == 15
       end
     end
+
+    context 'linter message' do
+      let(:scss) { <<-SCSS }
+      p {
+        property: $a,$b;
+      }
+      SCSS
+
+      it "specifies the style" do
+        subject.lints.first.description.should == 'Commas in lists should be followed by one space'
+      end
+    end
   end
 
   context 'when more than one space is preferred' do
@@ -757,6 +769,18 @@ describe SCSSLint::Linter::SpaceAfterComma do
         it { should_not report_lint }
       end
     end
+
+    context 'linter message' do
+      let(:scss) { <<-SCSS }
+      p {
+        property: $a,$b;
+      }
+      SCSS
+
+      it "specifies the style" do
+        subject.lints.first.description.should == 'Commas in lists should be followed by at least one space'
+      end
+    end
   end
 
   context 'when no space is preferred' do
@@ -1088,6 +1112,18 @@ describe SCSSLint::Linter::SpaceAfterComma do
         SCSS
 
         it { should_not report_lint }
+      end
+    end
+
+    context 'linter message' do
+      let(:scss) { <<-SCSS }
+      p {
+        property: $a, $b;
+      }
+      SCSS
+
+      it "specifies the style" do
+        subject.lints.first.description.should == 'Commas in lists should be followed by no space'
       end
     end
   end


### PR DESCRIPTION
For this example:

```scss
.test {
  color: rgba(0, 0,0,.1);
}
```

with the following configuration:

```
  SpaceAfterComma:
    enabled: true
    style: no_space
```

You get the following linter messages:

```
test.scss:2:1 [W] SpaceAfterComma: Commas in function arguments should be followed by a single space
test.scss:2:1 [W] SpaceAfterComma: Commas in function arguments should be followed by a single space
```

The two things I noticed here is:
 - the column number in the location is `1` (meaning the column number is set)
 - the linter message is set to `followed by a single space` regardless of your setting. 

This PR addresses both of these issues. With the changes, this is the output you would now get:

```
test.scss:2:19 [W] SpaceAfterComma: Commas in function arguments should be followed by one space
test.scss:2:21 [W] SpaceAfterComma: Commas in function arguments should be followed by one space
```