### PR TITLE
Fix default configuration for SpaceAfterComment

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -182,8 +182,8 @@ linters:
     style: one_space # or 'no_space', or 'at_least_one_space'
 
   SpaceAfterComment:
-    enabled: true
-    style: at_least_one_space # or 'no_space', or 'at_least_one_space'
+    enabled: false
+    style: one_space # or 'no_space', or 'at_least_one_space'
     allow_empty_comments: true
 
   SpaceAfterPropertyColon:


### PR DESCRIPTION
See #832

So sorry! I left these values in while testing. I've changed the default back to `one_space` and enabled to be `false` since new linters should have be off by default. Again, I apologize for this mistake! 