### PR TITLE
Allow loading config file from plugin directory

### DIFF
--- a/lib/scss_lint/plugins/linter_dir.rb
+++ b/lib/scss_lint/plugins/linter_dir.rb
@@ -6,11 +6,11 @@ module SCSSLint
 
       def initialize(dir)
         @dir = dir
-        @config = SCSSLint::Config.new({}) # Will always be empty
       end
 
       def load
         ruby_files.each { |file| require file }
+        @config = plugin_config
         self
       end
 
@@ -18,6 +18,29 @@ module SCSSLint
 
       def ruby_files
         Dir.glob(File.expand_path(File.join(@dir, '**', '*.rb')))
+      end
+
+      # Returns the {SCSSLint::Config} for this directory.
+      #
+      # This is intended to be merged with the configuration that loaded this
+      # plugin.
+      #
+      # @return [SCSSLint::Config]
+      def plugin_config
+        file = plugin_config_file
+
+        if File.exist?(file)
+          Config.load(file, merge_with_default: false)
+        else
+          Config.new({})
+        end
+      end
+
+      # Path of the configuration file to attempt to load for this directory.
+      #
+      # @return [String]
+      def plugin_config_file
+        File.join(@dir, Config::FILE_NAME)
       end
     end
   end

--- a/spec/scss_lint/plugins/linter_dir_spec.rb
+++ b/spec/scss_lint/plugins/linter_dir_spec.rb
@@ -4,18 +4,42 @@ describe SCSSLint::Plugins::LinterDir do
   let(:plugin_directory) { File.expand_path('../../fixtures/plugins', __FILE__) }
   let(:subject) { described_class.new(plugin_directory) }
 
-  describe '#config' do
-    it 'returns empty configuration' do
-      subject.config.should == SCSSLint::Config.new({})
-    end
-  end
-
   describe '#load' do
+    let(:config_file) { File.join(plugin_directory, '.scss-lint.yml') }
+    let(:config_file_exists) { false }
+
+    before do
+      File.stub(:exist?).with(config_file).and_return(config_file_exists)
+    end
+
     it 'requires each file in the plugin directory' do
       subject.should_receive(:require)
              .with(File.join(plugin_directory, 'linter_plugin.rb')).once
 
       subject.load
+    end
+
+    context 'when the dir does not include a configuration file' do
+      it 'loads an empty configuration' do
+        subject.load
+        subject.config.should == SCSSLint::Config.new({})
+      end
+    end
+
+    context 'when a config file exists in the dir' do
+      let(:config_file_exists) { true }
+      let(:fake_config) { SCSSLint::Config.new('linters' => { 'FakeLinter' => {} }) }
+
+      before do
+        SCSSLint::Config.should_receive(:load)
+                        .with(config_file, merge_with_default: false)
+                        .and_return(fake_config)
+      end
+
+      it 'loads the configuration' do
+        subject.load
+        subject.config.should == fake_config
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

`plugin_directories` property can be used in `.scss-lint.yml` to load additional linters from a directory. However it does not allow loading custom `.scss-lint.yml` for such directory.

This PR allows loading a custom `.scss-lint.yml` from any directory specified in `plugin_directories` and merge it with your existing configuration. This is pretty handy to allow extending your existing configuration from other configuration coming from other non-gem package, e.g. npm, bower, etc.

# What was done

- [x] Update `linter_dir.rb` to add loading custom `.scss-lint.yml` functionality (based on `linter_gem`)
- [x] Update the spec accordingly

# Note

While `scss-linter` allows loading `.scss-lint.yml` file from other `gems` it sometimes happen that you need to extend your project config from another `.scss-lint.yml` that is not coming from a `gem` but from another directory or another non-gem package, like npm, bower, etc.

```
# .scss-lint.yml
plugin_directories: ['.scss-linters', 'node_modules/custom_package']
```

Might be related to https://github.com/brigade/scss-lint/issues/516