### PR TITLE
Allows the ignoring of variables being reported in UrlFormatter

### DIFF
--- a/lib/scss_lint/linter/url_format.rb
+++ b/lib/scss_lint/linter/url_format.rb
@@ -43,7 +43,7 @@ module SCSSLint
     end
 
     def check_url(url, node)
-      return if url.start_with?('data:')
+      return if url.start_with?('data:') || url.include?('${')
       uri = URI(url)
 
       if uri.scheme || uri.host

--- a/spec/scss_lint/linter/url_format_spec.rb
+++ b/spec/scss_lint/linter/url_format_spec.rb
@@ -33,7 +33,11 @@ describe SCSSLint::Linter::UrlFormat do
     end
 
     context 'when URL contains a variable' do
-      let(:url) { '${' }
+      let(:scss) { <<-SCSS }
+        .block {
+          background: url('${url}');
+        }
+      SCSS
 
       it { should_not report_lint }
     end

--- a/spec/scss_lint/linter/url_format_spec.rb
+++ b/spec/scss_lint/linter/url_format_spec.rb
@@ -33,7 +33,11 @@ describe SCSSLint::Linter::UrlFormat do
     end
 
     context 'when URL contains a variable' do
-      let(:url) { '${url}' }
+      let(:scss) { <<-SCSS }
+        .block {
+          background: url('${url}');
+        }
+      SCSS
 
       it { should_not report_lint }
     end

--- a/spec/scss_lint/linter/url_format_spec.rb
+++ b/spec/scss_lint/linter/url_format_spec.rb
@@ -33,11 +33,7 @@ describe SCSSLint::Linter::UrlFormat do
     end
 
     context 'when URL contains a variable' do
-      let(:scss) { <<-SCSS }
-        .block {
-          background: url('${url}');
-        }
-      SCSS
+      let(:url) { '${url}' }
 
       it { should_not report_lint }
     end

--- a/spec/scss_lint/linter/url_format_spec.rb
+++ b/spec/scss_lint/linter/url_format_spec.rb
@@ -31,6 +31,12 @@ describe SCSSLint::Linter::UrlFormat do
 
       it { should_not report_lint }
     end
+
+    context 'when URL contains a variable' do
+      let(:url) { '${' }
+
+      it { should_not report_lint }
+    end
   end
 
   context 'when URL is enclosed in quotes' do


### PR DESCRIPTION
Currently only ignores data but now also ignores `${`