### PR TITLE
Fix non-lint in import indentation when leading newline

### DIFF
--- a/lib/scss_lint/linter/indentation.rb
+++ b/lib/scss_lint/linter/indentation.rb
@@ -98,7 +98,7 @@ module SCSSLint
 
     def visit_import(node)
       prev = previous_node(node)
-      return if prev.is_a?(Sass::Tree::ImportNode) && source_from_range(prev.source_range) =~ /,$/
+      return unless engine.lines[node.line - 1] =~ /@import/
       check_indentation(node)
     end
 

--- a/spec/scss_lint/linter/indentation_spec.rb
+++ b/spec/scss_lint/linter/indentation_spec.rb
@@ -238,6 +238,16 @@ describe SCSSLint::Linter::Indentation do
     it { should_not report_lint }
   end
 
+  context 'when an @import spans multiple lines and leads with a newline' do
+    let(:scss) { <<-SCSS }
+      @import
+          'foo',
+          'bar';
+    SCSS
+
+    it { should_not report_lint }
+  end
+
   context 'when tabs are preferred' do
     let(:linter_config) { { 'character' => 'tab', 'width' => 1 } }
 


### PR DESCRIPTION
The Indentation linter was complaining about lines like this:

```scss
@import
    'foo',
    'bar';
```

wanting all the lines to be at indentation 0. This suppresses that warning.