### PR TITLE
Add support for the ::ng-deep pseudo-element

### DIFF
--- a/data/pseudo-elements.txt
+++ b/data/pseudo-elements.txt
@@ -110,6 +110,7 @@ before
 content
 first-letter
 first-line
+ng-deep
 placeholder
 selection
 shadow


### PR DESCRIPTION
Angular has added the `::ng-deep` pseudo-element in angular/angular@b754e600e30476a22e29019d89df71dd9b7fcbd5 as a CSS-compliant replacement for `/deep/` and `>>>`. This avoids having the linter complain about this element.