### PR TITLE
Release sass dependency

### DIFF
--- a/lib/scss_lint.rb
+++ b/lib/scss_lint.rb
@@ -31,3 +31,28 @@ require 'scss_lint/reporter'
 Dir[File.expand_path('scss_lint/reporter/**/*.rb', File.dirname(__FILE__))].sort.each do |file|
   require file
 end
+
+# Sass::Tree::PropNode#value returns an array in new versions. Here is note from docs:
+#
+#   For most properties, this will just contain a single Node. However, for
+#   CSS variables, it will contain multiple strings and nodes representing
+#   interpolation.
+#
+# This monkey-patch allows us use scss-lint with new versions of sass.
+Array.class_eval do
+  def to_sass_value
+    raise 'This proxy does not support css variables' unless size == 1
+    first
+  end
+
+  def to_sass
+    to_sass_value.to_sass
+  end
+end
+
+Sass::Script::Tree::Node.class_eval do
+  # We use #to_sass_value to keep it compatible to sass < 3.5.
+  def to_sass_value
+    self
+  end
+end

--- a/lib/scss_lint/linter/duplicate_property.rb
+++ b/lib/scss_lint/linter/duplicate_property.rb
@@ -54,6 +54,7 @@ module SCSSLint
     end
 
     def value_as_string(value)
+      value = value.to_sass_value
       case value
       when Sass::Script::Funcall
         value.name

--- a/lib/scss_lint/linter/property_units.rb
+++ b/lib/scss_lint/linter/property_units.rb
@@ -32,8 +32,9 @@ module SCSSLint
         property = "#{@nested_under}-#{property}"
       end
 
-      if node.value.respond_to?(:value)
-        node.value.value.to_s.scan(NUMBER_WITH_UNITS_REGEX).each do |matches|
+      value = node.value.to_sass_value
+      if value.respond_to?(:value)
+        value.value.to_s.scan(NUMBER_WITH_UNITS_REGEX).each do |matches|
           is_quoted_value = !matches[0].nil?
           next if is_quoted_value
           units = matches[1]

--- a/lib/scss_lint/linter/shorthand.rb
+++ b/lib/scss_lint/linter/shorthand.rb
@@ -22,11 +22,12 @@ module SCSSLint
 
       end
 
-      case node.value
+      value = node.value.to_sass_value
+      case value
       when Sass::Script::Tree::Literal
-        check_script_literal(property_name, node.value)
+        check_script_literal(property_name, value)
       when Sass::Script::Tree::ListLiteral
-        check_script_list(property_name, node.value)
+        check_script_list(property_name, value)
       end
     end
 

--- a/lib/scss_lint/linter/url_format.rb
+++ b/lib/scss_lint/linter/url_format.rb
@@ -17,8 +17,9 @@ module SCSSLint
     end
 
     def visit_prop(node)
-      if url_literal?(node.value)
-        url = node.value.to_sass.sub(/^url\((.*)\)$/, '\\1')
+      value = node.value.to_sass_value
+      if url_literal?(value)
+        url = value.to_sass.sub(/^url\((.*)\)$/, '\\1')
         check_url(url, node)
       end
 

--- a/lib/scss_lint/linter/url_quotes.rb
+++ b/lib/scss_lint/linter/url_quotes.rb
@@ -4,11 +4,12 @@ module SCSSLint
     include LinterRegistry
 
     def visit_prop(node)
-      case node.value
+      value = node.value.to_sass_value
+      case value
       when Sass::Script::Tree::Literal
-        check(node, node.value.value.to_s)
+        check(node, value.value.to_s)
       when Sass::Script::Tree::ListLiteral
-        node.value
+        value
             .children
             .select { |child| child.is_a?(Sass::Script::Tree::Literal) }
             .each { |child| check(node, child.value.to_s) }

--- a/lib/scss_lint/linter/url_quotes.rb
+++ b/lib/scss_lint/linter/url_quotes.rb
@@ -10,9 +10,9 @@ module SCSSLint
         check(node, value.value.to_s)
       when Sass::Script::Tree::ListLiteral
         value
-            .children
-            .select { |child| child.is_a?(Sass::Script::Tree::Literal) }
-            .each { |child| check(node, child.value.to_s) }
+          .children
+          .select { |child| child.is_a?(Sass::Script::Tree::Literal) }
+          .each { |child| check(node, child.value.to_s) }
       end
 
       yield

--- a/lib/scss_lint/linter/variable_for_property.rb
+++ b/lib/scss_lint/linter/variable_for_property.rb
@@ -12,10 +12,11 @@ module SCSSLint
 
     def visit_prop(node)
       property_name = node.name.join
+      value = node.value.to_sass_value
       return unless @properties.include?(property_name)
-      return if ignored_value?(node.value)
+      return if ignored_value?(value)
       return if node.children.first.is_a?(Sass::Script::Tree::Variable)
-      return if variable_property_with_important?(node.value)
+      return if variable_property_with_important?(value)
 
       add_lint(node, "Property #{property_name} should use " \
                      'a variable rather than a literal value')

--- a/lib/scss_lint/linter/vendor_prefix.rb
+++ b/lib/scss_lint/linter/vendor_prefix.rb
@@ -16,8 +16,12 @@ module SCSSLint
       check_identifier(node, name.sub(/^@/, ''))
 
       # Check for values
-      return unless node.respond_to?(:value) && node.value.respond_to?(:source_range)
-      check_identifier(node, source_from_range(node.value.source_range))
+      return unless node.respond_to?(:value)
+      value = node.value
+      # TODO: should this be fixed to support arrays with multiple values?
+      value = value.first if value.is_a?(Array)
+      return unless value.respond_to?(:source_range)
+      check_identifier(node, source_from_range(value.source_range))
     end
 
     alias visit_prop check_node

--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2'
 
   s.add_dependency 'rake', '>= 0.9', '< 13'
-  s.add_dependency 'sass', '~> 3.4.20'
+  s.add_dependency 'sass', '>= 3.4.20', '< 4'
 end

--- a/spec/scss_lint/report_lint_spec.rb
+++ b/spec/scss_lint/report_lint_spec.rb
@@ -32,7 +32,7 @@ describe 'report_lint' do
 
       expect do
         should_not report_lint
-      end.to fail_with 'expected that a lint would not be reported'
+      end.to fail_with(/expected that a lint would not be reported/)
     end
   end
 
@@ -58,7 +58,7 @@ describe 'report_lint' do
 
       expect do
         should_not report_lint line: 1
-      end.to fail_with 'expected that a lint would not be reported'
+      end.to fail_with(/expected that a lint would not be reported/)
     end
   end
 
@@ -84,7 +84,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint
-      end.to fail_with 'expected that a lint would be reported'
+      end.to fail_with 'expected that a lint would be reported, but got nothing'
     end
   end
 
@@ -110,7 +110,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint line: 1
-      end.to fail_with 'expected that a lint would be reported on line 1'
+      end.to fail_with('expected that a lint would be reported on line 1, but got nothing')
     end
 
     it 'fails to match lints on the wrong line with a meaningful message' do
@@ -137,7 +137,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint count: 1
-      end.to fail_with 'expected that exactly 1 lint would be reported'
+      end.to fail_with 'expected that exactly 1 lint would be reported, but got nothing'
     end
 
     it 'fails to match multiple lints with a meaningful message' do
@@ -173,7 +173,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint count: 2
-      end.to fail_with 'expected that exactly 2 lints would be reported'
+      end.to fail_with 'expected that exactly 2 lints would be reported, but got nothing'
     end
 
     it 'fails to match one lint with a meaningful message' do
@@ -181,7 +181,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint count: 2
-      end.to fail_with 'expected that exactly 2 lints would be reported'
+      end.to fail_with 'expected that exactly 2 lints would be reported, but got nothing'
     end
 
     it 'fails to match lints on the wrong line with a meaningful message' do
@@ -208,7 +208,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint line: 1, count: 1
-      end.to fail_with 'expected that exactly 1 lint would be reported on line 1'
+      end.to fail_with 'expected that exactly 1 lint would be reported on line 1, but got nothing'
     end
 
     it 'fails to match multiple lints with a meaningful message' do
@@ -244,7 +244,7 @@ describe 'report_lint' do
 
       expect do
         should report_lint line: 1, count: 2
-      end.to fail_with 'expected that exactly 2 lints would be reported on line 1'
+      end.to fail_with 'expected that exactly 2 lints would be reported on line 1, but got nothing'
     end
 
     it 'fails to match one lint with a meaningful message' do

--- a/spec/support/matchers/report_lint.rb
+++ b/spec/support/matchers/report_lint.rb
@@ -21,7 +21,7 @@ RSpec::Matchers.define :report_lint do |options|
       (expected_line ? " on line #{expected_line}" : '') +
       case linter.lints.count
       when 0
-        ''
+        ', but got nothing'
       when 1
         ", but one lint was reported on line #{linter.lints.first.location.line}"
       else
@@ -30,8 +30,9 @@ RSpec::Matchers.define :report_lint do |options|
       end
   end
 
-  failure_message_when_negated do
-    'expected that a lint would not be reported'
+  failure_message_when_negated do |linter|
+    reports = linter.lints.map(&:description).join("\n  ")
+    "expected that a lint would not be reported, got:\n  #{reports}"
   end
 
   description do


### PR DESCRIPTION
Hi! I've got this error:
```
    bootstrap (= 4.0.0.beta2.1) was resolved to 4.0.0.beta2.1, which depends on
      sass (>= 3.5.2)

    scss_lint was resolved to 0.38.0, which depends on
      sass (~> 3.4.1)
```

It should be ok not to use `~>`, as only `sass@4.x.x` may introduce breaking changes.