### PR TITLE
Make all lint to have `linter` attribute

### DIFF
--- a/lib/scss_lint/linter/encoding.rb
+++ b/lib/scss_lint/linter/encoding.rb
@@ -1,0 +1,4 @@
+module SCSSLint
+  class Linter::Encoding < Linter
+  end
+end

--- a/lib/scss_lint/linter/syntax.rb
+++ b/lib/scss_lint/linter/syntax.rb
@@ -1,0 +1,4 @@
+module SCSSLint
+  class Linter::Syntax < Linter
+  end
+end

--- a/lib/scss_lint/reporter/config_reporter.rb
+++ b/lib/scss_lint/reporter/config_reporter.rb
@@ -19,7 +19,6 @@ module SCSSLint
     end
 
     def linter_name(linter)
-      return unless linter
       linter.class.to_s.split('::').last
     end
   end

--- a/lib/scss_lint/reporter/default_reporter.rb
+++ b/lib/scss_lint/reporter/default_reporter.rb
@@ -24,7 +24,7 @@ module SCSSLint
     end
 
     def message(lint)
-      linter_name = log.green("#{lint.linter.name}: ") if lint.linter
+      linter_name = log.green("#{lint.linter.name}: ")
       "#{linter_name}#{lint.description}"
     end
   end

--- a/lib/scss_lint/reporter/json_reporter.rb
+++ b/lib/scss_lint/reporter/json_reporter.rb
@@ -23,7 +23,7 @@ module SCSSLint
         'severity' => lint.severity,
         'reason' => lint.description,
       }.tap do |hash|
-        hash['linter'] = lint.linter.name if lint.linter
+        hash['linter'] = lint.linter.name
       end
     end
   end

--- a/lib/scss_lint/reporter/tap_reporter.rb
+++ b/lib/scss_lint/reporter/tap_reporter.rb
@@ -95,10 +95,8 @@ module SCSSLint
         'column' => lint.location.column,
       }
 
-      if lint.linter
-        test_line_description += " #{lint.linter.name}" if lint.linter
-        data['name'] = lint.linter.name
-      end
+      test_line_description += " #{lint.linter.name}"
+      data['name'] = lint.linter.name
 
       data_yaml = data.to_yaml.strip.gsub(/^/, '  ')
 

--- a/lib/scss_lint/runner.rb
+++ b/lib/scss_lint/runner.rb
@@ -41,10 +41,10 @@ module SCSSLint
         end
       end
     rescue Sass::SyntaxError => ex
-      @lints << Lint.new(nil, ex.sass_filename, Location.new(ex.sass_line),
+      @lints << Lint.new(Linter::Syntax.new, ex.sass_filename, Location.new(ex.sass_line),
                          "Syntax Error: #{ex}", :error)
     rescue FileEncodingError => ex
-      @lints << Lint.new(nil, file[:path], Location.new, ex.to_s, :error)
+      @lints << Lint.new(Linter::Encoding.new, file[:path], Location.new, ex.to_s, :error)
     end
 
     # For stubbing in tests.

--- a/spec/scss_lint/reporter/clean_files_reporter_spec.rb
+++ b/spec/scss_lint/reporter/clean_files_reporter_spec.rb
@@ -39,7 +39,7 @@ describe SCSSLint::Reporter::CleanFilesReporter do
 
       let(:lints) do
         dirty_files.map do |file|
-          SCSSLint::Lint.new(nil, file, SCSSLint::Location.new, '')
+          SCSSLint::Lint.new(SCSSLint::Linter::Comment.new, file, SCSSLint::Location.new, '')
         end
       end
 
@@ -61,7 +61,7 @@ describe SCSSLint::Reporter::CleanFilesReporter do
 
       let(:lints) do
         files.map do |file|
-          SCSSLint::Lint.new(nil, file, SCSSLint::Location.new, '')
+          SCSSLint::Lint.new(SCSSLint::Linter::Comment.new, file, SCSSLint::Location.new, '')
         end
       end
 

--- a/spec/scss_lint/reporter/config_reporter_spec.rb
+++ b/spec/scss_lint/reporter/config_reporter_spec.rb
@@ -16,11 +16,11 @@ describe SCSSLint::Reporter::ConfigReporter do
     context 'when there are lints' do
       let(:linters) do
         [SCSSLint::Linter::FinalNewline, SCSSLint::Linter::BorderZero,
-         SCSSLint::Linter::BorderZero, nil]
+         SCSSLint::Linter::BorderZero]
       end
       let(:lints) do
         linters.each.map do |linter|
-          SCSSLint::Lint.new(linter ? linter.new : nil, '',
+          SCSSLint::Lint.new(linter.new, '',
                              SCSSLint::Location.new, '')
         end
       end

--- a/spec/scss_lint/reporter/default_reporter_spec.rb
+++ b/spec/scss_lint/reporter/default_reporter_spec.rb
@@ -22,7 +22,7 @@ describe SCSSLint::Reporter::DefaultReporter do
         filenames.each_with_index.map do |filename, index|
           line, column = locations[index]
           location = SCSSLint::Location.new(line, column, 10)
-          SCSSLint::Lint.new(nil, filename, location, descriptions[index],
+          SCSSLint::Lint.new(SCSSLint::Linter::Comment, filename, location, descriptions[index],
                              severities[index])
         end
       end

--- a/spec/scss_lint/reporter/files_reporter_spec.rb
+++ b/spec/scss_lint/reporter/files_reporter_spec.rb
@@ -17,7 +17,7 @@ describe SCSSLint::Reporter::FilesReporter do
 
       let(:lints) do
         filenames.map do |filename|
-          SCSSLint::Lint.new(nil, filename, SCSSLint::Location.new, '')
+          SCSSLint::Lint.new(SCSSLint::Linter::Comment.new, filename, SCSSLint::Location.new, '')
         end
       end
 

--- a/spec/scss_lint/reporter/json_reporter_spec.rb
+++ b/spec/scss_lint/reporter/json_reporter_spec.rb
@@ -35,7 +35,7 @@ describe SCSSLint::Reporter::JSONReporter do
 
       let(:lints) do
         filenames.each_with_index.map do |filename, index|
-          SCSSLint::Lint.new(nil, filename, locations[index],
+          SCSSLint::Lint.new(SCSSLint::LinterRegistry.linters.sample, filename, locations[index],
                              descriptions[index], severities[index])
         end
       end


### PR DESCRIPTION
Problem
===

Currently SCSS-Lint reports syntax and encoding issues without `linter` attribute.
For example:

`test.scss`

```scss
{
```

`valid.scss`

```scss
a {
  border: none;
}
```

```bash
$ scss-lint --format JSON
{
  "test.scss": [
    {
      # This issue does not have `linter` attribute.
      "line": 1,
      "column": 1,
      "length": 1,
      "severity": "error",
      "reason": "Syntax Error: Invalid CSS after \"\": expected selector or at-rule, was \"{\""
    }
  ],
  "valid.scss": [
    {
      "line": 2,
      "column": 3,
      "length": 12,
      "severity": "warning",
      "reason": "`border: 0` is preferred over `border: none`",
      "linter": "BorderZero" # This issue has `linter` attribute.
    }
  ]
}
```



This behaviour is difficult to handle. We develop [SideCI](https://sideci.com) that is a automated code review service. SideCI uses SCSS-Lint, and we expect that all issues have a issue type, that is called "linter" in SCSS-Lint. But SCSS-Lint's syntax issue does not have "linter". So our program crashes.

Solution
====


Make all lint to have `linter` attribute.
In other words, I added `Linter::Syntax` and `Linter::Encoding`class, and use these classes instead of nil, and removed `lint.linter` existence check.



