### PR TITLE
Support Sass 3.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 1.9 # Oldest version of Ruby we support
+  DisplayCopNames: true
+  TargetRubyVersion: 2.0 # Oldest version of Ruby we support
 
 AccessModifierIndentation:
   EnforcedStyle: outdent
@@ -24,9 +25,6 @@ Documentation:
   Exclude:
     - 'spec/scss_lint/**/*'
     - 'spec/scss_lint/linter/**/*'
-
-Encoding:
-  EnforcedStyle: when_needed
 
 Eval:
   Exclude:
@@ -66,10 +64,10 @@ Layout/MultilineOperationIndentation:
   Enabled: false
 
 LineLength:
-  Max: 100
+  Max: 102
 
-# Reports false positives for `CONSTANT % ['value', 'value']` (RuboCop 0.33.0)
-Lint/FormatParameterMismatch:
+# Reports false positives for `'.one #{$interpolated-string} .two .three {}'` (RuboCop v0.50.0)
+Lint/InterpolationCheck:
   Enabled: false
 
 MethodLength:
@@ -103,9 +101,6 @@ PercentLiteralDelimiters:
 PredicateName:
   Enabled: false
 
-SignalException:
-  Enabled: false
-
 # Forcing a particular name (e.g. |a, e|) for inject methods prevents you from
 # choosing intention-revealing names.
 SingleLineBlockParams:
@@ -122,7 +117,4 @@ Style/TrailingCommaInArguments:
   Enabled: false
 
 Style/TrailingCommaInLiteral:
-  Enabled: false
-
-UselessAccessModifier:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ env:
 
 rvm:
   - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.1
-  - jruby-9.1.6.0
+  - 2.1.10
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - jruby-9.1.13.0
 
 before_script:
   - git config --local user.email "travis@travis.ci"

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rspec', '~> 3.6.0'
+gem 'rspec', '~> 3.7'
 
 # Run all pre-commit checks via Overcommit during CI runs
-gem 'overcommit', '0.39.1'
+gem 'overcommit', '~> 0.41.0'
 
 # Pin tool versions (which are executed by Overcommit) for Travis builds
-gem 'rubocop', '0.49.1'
+gem 'rubocop', '0.50.0'
 
 gem 'coveralls', require: false

--- a/lib/scss_lint/cli.rb
+++ b/lib/scss_lint/cli.rb
@@ -31,7 +31,7 @@ module SCSSLint
     def run(args)
       options = SCSSLint::Options.new.parse(args)
       act_on_options(options)
-    rescue => ex
+    rescue StandardError => ex
       handle_runtime_exception(ex, options)
     end
 

--- a/lib/scss_lint/config.rb
+++ b/lib/scss_lint/config.rb
@@ -64,7 +64,7 @@ module SCSSLint
             else
               {}
             end
-        rescue => ex
+        rescue StandardError => ex
           raise SCSSLint::Exceptions::InvalidConfiguration,
                 "Invalid configuration: #{ex.message}"
         end
@@ -95,12 +95,15 @@ module SCSSLint
       def merge_wildcard_linter_options(options)
         options = options.dup
 
+        # rubocop:disable Performance/HashEachMethods (FALSE POSITIVE)
+        # Cannot use `each_key` because the cycle adds new keys during iteration
         options.fetch('linters', {}).keys.each do |class_name|
           next unless class_name.include?('*')
 
           wildcard_options = options['linters'].delete(class_name)
           apply_options_to_matching_linters(class_name, options, wildcard_options)
         end
+        # rubocop:enable Performance/HashEachMethods
 
         options
       end
@@ -124,7 +127,7 @@ module SCSSLint
 
         options['linters'] ||= {}
 
-        options['linters'].keys.each do |linter_name|
+        options['linters'].each_key do |linter_name|
           options['linters'][linter_name] =
             ensure_exclude_paths_are_absolute(options['linters'][linter_name], original_file)
         end
@@ -264,7 +267,7 @@ module SCSSLint
     end
 
     def disable_all_linters
-      @options['linters'].values.each do |linter_config|
+      @options['linters'].each_value do |linter_config|
         linter_config['enabled'] = false
       end
     end
@@ -316,7 +319,7 @@ module SCSSLint
     def validate_linters
       return unless linters = @options['linters']
 
-      linters.keys.each do |name|
+      linters.each_key do |name|
         begin
           Linter.const_get(name)
         rescue NameError

--- a/lib/scss_lint/linter/border_zero.rb
+++ b/lib/scss_lint/linter/border_zero.rb
@@ -27,7 +27,7 @@ module SCSSLint
 
     def visit_prop(node)
       return unless BORDER_PROPERTIES.include?(node.name.first.to_s)
-      check_border(node, node.name.first.to_s, node.value.to_sass.strip)
+      check_border(node, node.name.first.to_s, node.value.first.to_sass.strip)
     end
 
   private

--- a/lib/scss_lint/linter/color_variable.rb
+++ b/lib/scss_lint/linter/color_variable.rb
@@ -19,10 +19,12 @@ module SCSSLint
     def visit_script_string(node)
       return if literal_string?(node)
 
+      # rubocop:disable Performance/HashEachMethods (FALSE POSITIVE v0.50.0)
       remove_quoted_strings(node.value)
         .scan(/(^|\s)(#[a-f0-9]+|[a-z]+)(?=\s|$)/i)
         .select { |_, word| color?(word) }
         .each   { |_, color| record_lint(node, color) }
+      # rubocop:enable Performance/HashEachMethods
     end
 
     def visit_script_funcall(node)

--- a/lib/scss_lint/linter/compass/property_with_mixin.rb
+++ b/lib/scss_lint/linter/compass/property_with_mixin.rb
@@ -33,7 +33,7 @@ module SCSSLint
     def check_for_inline_block(node)
       prop_name = node.name.join
       return unless prop_name == 'display' &&
-                    node.value.to_sass == 'inline-block' &&
+                    node.value.first.to_sass == 'inline-block' &&
                     !ignore_compass_mixin?('inline-block')
 
       add_lint node,

--- a/lib/scss_lint/linter/duplicate_property.rb
+++ b/lib/scss_lint/linter/duplicate_property.rb
@@ -43,7 +43,7 @@ module SCSSLint
     # for purposes of uniqueness.
     def property_key(prop)
       prop_key = prop.name.join
-      prop_value = value_as_string(prop.value)
+      prop_value = value_as_string(prop.value.first)
 
       # Differentiate between values for different vendor prefixes
       prop_value.to_s.scan(/^(-[^-]+-.+)/) do |vendor_keyword|

--- a/lib/scss_lint/linter/private_naming_convention.rb
+++ b/lib/scss_lint/linter/private_naming_convention.rb
@@ -132,7 +132,7 @@ module SCSSLint
     def after_visit_all
       return unless @private_definitions
 
-      @private_definitions.each do |_, nodes|
+      @private_definitions.each_value do |nodes|
         nodes.each do |node_text, node_info|
           next if node_info[:times_used] > 0
           node_type = humanize_node_class(node_info[:node])

--- a/lib/scss_lint/linter/property_sort_order.rb
+++ b/lib/scss_lint/linter/property_sort_order.rb
@@ -38,6 +38,7 @@ module SCSSLint
     alias visit_rule check_order
     alias visit_prop check_order
 
+    # rubocop:disable Lint/DuplicateMethods (FALSE POSITIVE v0.50.0)
     def visit_prop(node, &block)
       # Handle nested properties by appending the parent property they are
       # nested under to the name
@@ -45,6 +46,7 @@ module SCSSLint
       check_order(node, &block)
       @nested_under = nil
     end
+    # rubocop:enable Lint/DuplicateMethods
 
     def visit_if(node, &block)
       check_order(node, &block)

--- a/lib/scss_lint/linter/property_units.rb
+++ b/lib/scss_lint/linter/property_units.rb
@@ -32,8 +32,8 @@ module SCSSLint
         property = "#{@nested_under}-#{property}"
       end
 
-      if node.value.respond_to?(:value)
-        node.value.value.to_s.scan(NUMBER_WITH_UNITS_REGEX).each do |matches|
+      if node.value.first.respond_to?(:value)
+        node.value.first.value.to_s.scan(NUMBER_WITH_UNITS_REGEX).each do |matches|
           is_quoted_value = !matches[0].nil?
           next if is_quoted_value
           units = matches[1]

--- a/lib/scss_lint/linter/shorthand.rb
+++ b/lib/scss_lint/linter/shorthand.rb
@@ -22,11 +22,11 @@ module SCSSLint
 
       end
 
-      case node.value
+      case node.value.first
       when Sass::Script::Tree::Literal
-        check_script_literal(property_name, node.value)
+        check_script_literal(property_name, node.value.first)
       when Sass::Script::Tree::ListLiteral
-        check_script_list(property_name, node.value)
+        check_script_list(property_name, node.value.first)
       end
     end
 

--- a/lib/scss_lint/linter/space_before_brace.rb
+++ b/lib/scss_lint/linter/space_before_brace.rb
@@ -19,7 +19,6 @@ module SCSSLint
       check_node(node.else, &block) if node.else
     end
 
-    alias visit_function check_node
     alias visit_each check_node
     alias visit_for check_node
     alias visit_function check_node

--- a/lib/scss_lint/linter/transition_all.rb
+++ b/lib/scss_lint/linter/transition_all.rb
@@ -12,7 +12,7 @@ module SCSSLint
       property = node.name.first.to_s
       return unless TRANSITION_PROPERTIES.include?(property)
 
-      check_transition(node, property, node.value.to_sass)
+      check_transition(node, property, node.value.first.to_sass)
     end
 
   private

--- a/lib/scss_lint/linter/url_format.rb
+++ b/lib/scss_lint/linter/url_format.rb
@@ -17,8 +17,8 @@ module SCSSLint
     end
 
     def visit_prop(node)
-      if url_literal?(node.value)
-        url = node.value.to_sass.sub(/^url\((.*)\)$/, '\\1')
+      if url_literal?(node.value.first)
+        url = node.value.first.to_sass.sub(/^url\((.*)\)$/, '\\1')
         check_url(url, node)
       end
 

--- a/lib/scss_lint/linter/url_quotes.rb
+++ b/lib/scss_lint/linter/url_quotes.rb
@@ -4,11 +4,11 @@ module SCSSLint
     include LinterRegistry
 
     def visit_prop(node)
-      case node.value
+      case node.value.first
       when Sass::Script::Tree::Literal
-        check(node, node.value.value.to_s)
+        check(node, node.value.first.value.to_s)
       when Sass::Script::Tree::ListLiteral
-        node.value
+        node.value.first
             .children
             .select { |child| child.is_a?(Sass::Script::Tree::Literal) }
             .each { |child| check(node, child.value.to_s) }

--- a/lib/scss_lint/linter/variable_for_property.rb
+++ b/lib/scss_lint/linter/variable_for_property.rb
@@ -13,9 +13,9 @@ module SCSSLint
     def visit_prop(node)
       property_name = node.name.join
       return unless @properties.include?(property_name)
-      return if ignored_value?(node.value)
+      return if ignored_value?(node.value.first)
       return if node.children.first.is_a?(Sass::Script::Tree::Variable)
-      return if variable_property_with_important?(node.value)
+      return if variable_property_with_important?(node.value.first)
 
       add_lint(node, "Property #{property_name} should use " \
                      'a variable rather than a literal value')

--- a/lib/scss_lint/linter/vendor_prefix.rb
+++ b/lib/scss_lint/linter/vendor_prefix.rb
@@ -16,8 +16,8 @@ module SCSSLint
       check_identifier(node, name.sub(/^@/, ''))
 
       # Check for values
-      return unless node.respond_to?(:value) && node.value.respond_to?(:source_range)
-      check_identifier(node, source_from_range(node.value.source_range))
+      return unless node.respond_to?(:value) && node.value.first.respond_to?(:source_range)
+      check_identifier(node, source_from_range(node.value.first.source_range))
     end
 
     alias visit_prop check_node

--- a/lib/scss_lint/location.rb
+++ b/lib/scss_lint/location.rb
@@ -19,7 +19,7 @@ module SCSSLint
     end
 
     def ==(other)
-      [:line, :column, :length].all? do |attr|
+      %i[line column length].all? do |attr|
         send(attr) == other.send(attr)
       end
     end
@@ -27,7 +27,7 @@ module SCSSLint
     alias eql? ==
 
     def <=>(other)
-      [:line, :column, :length].each do |attr|
+      %i[line column length].each do |attr|
         result = send(attr) <=> other.send(attr)
         return result unless result == 0
       end

--- a/lib/scss_lint/reporter/tap_reporter.rb
+++ b/lib/scss_lint/reporter/tap_reporter.rb
@@ -102,11 +102,11 @@ module SCSSLint
 
       data_yaml = data.to_yaml.strip.gsub(/^/, '  ')
 
-      <<-EOS.strip
+      <<-LINES.strip
 not ok #{test_number} - #{test_line_description}
 #{data_yaml}
   ...
-      EOS
+      LINES
     end
 
     # @param output [Array<String>]

--- a/lib/scss_lint/runner.rb
+++ b/lib/scss_lint/runner.rb
@@ -33,7 +33,7 @@ module SCSSLint
       @linters.each do |linter|
         begin
           run_linter(linter, engine, file[:path])
-        rescue => error
+        rescue StandardError => error
           raise SCSSLint::Exceptions::LinterError,
                 "#{linter.class} raised unexpected error linting file #{file[:path]}: " \
                 "'#{error.message}'",

--- a/lib/scss_lint/sass/script.rb
+++ b/lib/scss_lint/sass/script.rb
@@ -74,24 +74,5 @@ module Sass::Script
         [value]
       end
     end
-
-    # This monkey patch can be removed once scss-lint depends on a minimum
-    # version of the sass gem that includes a fix for
-    # https://github.com/sass/sass/issues/1799
-    class ListLiteral
-      def source_range
-        return @source_range if @elements.empty?
-        @source_range.end_pos = @elements.last.source_range.end_pos
-        @source_range
-      end
-    end
-
-    class MapLiteral
-      def source_range
-        return @source_range if @pairs.empty?
-        @source_range.end_pos = @pairs.last.last.source_range.end_pos
-        @source_range
-      end
-    end
   end
 end

--- a/lib/scss_lint/sass/tree.rb
+++ b/lib/scss_lint/sass/tree.rb
@@ -11,15 +11,6 @@ module Sass::Tree
     # Stores node for which this node is a direct child
     attr_accessor :node_parent
 
-    # The `args` field of some Sass::Tree::Node classes returns
-    # Sass::Script::Variable nodes with no line numbers. This adds the line
-    # numbers back in so lint reporting works for those nodes.
-    def add_line_numbers_to_args(arg_list)
-      arg_list.each do |variable, _default_expr|
-        add_line_number(variable)
-      end
-    end
-
     # The Sass parser sometimes doesn't assign line numbers in cases where it
     # should. This is a helper to easily correct that.
     def add_line_number(node)
@@ -96,8 +87,6 @@ module Sass::Tree
 
   class FunctionNode
     def children
-      add_line_numbers_to_args(args)
-
       concat_expr_lists super, args, splat
     end
   end
@@ -110,16 +99,12 @@ module Sass::Tree
 
   class MixinDefNode
     def children
-      add_line_numbers_to_args(args)
-
       concat_expr_lists super, args, splat
     end
   end
 
   class MixinNode
     def children
-      add_line_numbers_to_args(args)
-
       # Keyword mapping is String -> Expr, so convert the string to a variable
       # node that supports lint reporting
       if keywords.any?

--- a/lib/scss_lint/sass/tree.rb
+++ b/lib/scss_lint/sass/tree.rb
@@ -134,6 +134,8 @@ module Sass::Tree
 
   class PropNode
     def children
+      # TODO: fix custom properties
+      return [] if custom_property?
       concat_expr_lists super, extract_script_nodes(name), add_line_number(value)
     end
   end

--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2'
 
   s.add_dependency 'rake', '>= 0.9', '< 13'
-  s.add_dependency 'sass', '~> 3.4.20'
+  s.add_dependency 'sass', '~> 3.5.3'
 end

--- a/spec/scss_lint/engine_spec.rb
+++ b/spec/scss_lint/engine_spec.rb
@@ -14,6 +14,18 @@ describe SCSSLint::Engine do
     end
   end
 
+  context 'when a custom property is present' do
+    let(:scss) { <<-SCSS }
+      :root {
+        --my-font-family: Helvetica;
+      }
+    SCSS
+
+    it 'has a parse tree' do
+      engine.tree.should_not be_nil
+    end
+  end
+
   context 'when the file being linted has an invalid byte sequence' do
     let(:scss) { "\xC0\u0001" }
 

--- a/spec/scss_lint/linter/trailing_semicolon_spec.rb
+++ b/spec/scss_lint/linter/trailing_semicolon_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe SCSSLint::Linter::TrailingSemicolon do

--- a/spec/scss_lint/linter_spec.rb
+++ b/spec/scss_lint/linter_spec.rb
@@ -13,7 +13,7 @@ describe SCSSLint::Linter do
         end
 
         def visit_prop(node)
-          return unless node.value.to_sass.strip == 'fail1'
+          return unless node.value.first.to_sass.strip == 'fail1'
           add_lint(node, 'everything offends me')
         end
 
@@ -29,7 +29,7 @@ describe SCSSLint::Linter do
               .select { |child| child.is_a?(Sass::Tree::PropNode) }
               .reject { |prop| prop.name.any? { |item| item.is_a?(Sass::Script::Node) } }
               .each do |prop|
-                add_lint(prop, 'everything offends me 2') if prop.value.to_sass.strip == 'fail2'
+                add_lint(prop, 'everything offends me 2') if prop.value.first.to_sass.strip == 'fail2'
               end
 
           yield

--- a/spec/scss_lint/reporter/tap_reporter_spec.rb
+++ b/spec/scss_lint/reporter/tap_reporter_spec.rb
@@ -20,12 +20,12 @@ describe SCSSLint::Reporter::TAPReporter do
       let(:lints) { [] }
 
       it 'returns the TAP version, plan, and ok test lines' do
-        subject.report_lints.should eq(<<-EOS)
+        subject.report_lints.should eq(<<-LINES)
 TAP version 13
 1..2
 ok 1 - file.scss
 ok 2 - another-file.scss
-        EOS
+        LINES
       end
     end
 
@@ -59,7 +59,7 @@ ok 2 - another-file.scss
       end
 
       it 'returns the TAP version, plan, and correct test lines' do
-        subject.report_lints.should eq(<<-EOS)
+        subject.report_lints.should eq(<<-LINES)
 TAP version 13
 1..5
 ok 1 - ok1.scss
@@ -91,7 +91,7 @@ not ok 4 - not-ok2.scss:21:3 SCSSLint::Linter::PrivateNamingConvention
   name: SCSSLint::Linter::PrivateNamingConvention
   ...
 ok 5 - ok2.scss
-        EOS
+        LINES
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
-    c.syntax = [:expect, :should]
+    c.syntax = %i[expect should]
   end
 
   config.mock_with :rspec do |c|


### PR DESCRIPTION
This is not the PR we deserve, but it's the one we need right now. 

Sass 3.5 is supported, custom properties aren't: all specs are green (included the new one which deals with custom properties), and it does not fail against Bootstrap v4

Also:
- Update development gems
- Test against latest Ruby versions
- Fix all new (0.50.0) RuboCop offences

Fix #877  
