### PR TITLE
Fix RuboCop offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,7 @@ Layout/MultilineOperationIndentation:
   Enabled: false
 
 LineLength:
-  Max: 102
+  Max: 103
 
 # Reports false positives for `'.one #{$interpolated-string} .two .three {}'` (RuboCop v0.50.0)
 Lint/InterpolationCheck:

--- a/lib/scss_lint/linter/private_naming_convention.rb
+++ b/lib/scss_lint/linter/private_naming_convention.rb
@@ -24,7 +24,7 @@ module SCSSLint
 
     def visit_root(node)
       # Register all top-level function, mixin, and variable definitions.
-      node.children.each_with_object([]) do |child_node|
+      node.children.each do |child_node|
         if DEFINITIONS.key?(child_node.class)
           register_node child_node
         end
@@ -97,7 +97,7 @@ module SCSSLint
     def node_defined_earlier_in_branch?(node_to_look_in, looking_for)
       # Look at all of the children of this node and return true if we find a
       # defining node that matches in name and type.
-      node_to_look_in.children.each_with_object([]) do |child_node|
+      node_to_look_in.children.each do |child_node|
         break unless before?(child_node, looking_for[:location])
         next unless child_node.class == looking_for[:defined_by]
         next unless child_node.name == looking_for[:node].name

--- a/lib/scss_lint/linter/property_sort_order.rb
+++ b/lib/scss_lint/linter/property_sort_order.rb
@@ -36,9 +36,7 @@ module SCSSLint
     alias visit_media check_order
     alias visit_mixin check_order
     alias visit_rule check_order
-    alias visit_prop check_order
 
-    # rubocop:disable Lint/DuplicateMethods (FALSE POSITIVE v0.50.0)
     def visit_prop(node, &block)
       # Handle nested properties by appending the parent property they are
       # nested under to the name
@@ -46,7 +44,6 @@ module SCSSLint
       check_order(node, &block)
       @nested_under = nil
     end
-    # rubocop:enable Lint/DuplicateMethods
 
     def visit_if(node, &block)
       check_order(node, &block)

--- a/lib/scss_lint/linter/shorthand.rb
+++ b/lib/scss_lint/linter/shorthand.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/CyclomaticComplexity
 module SCSSLint
   # Checks for the use of the shortest form for properties that can be written
   # in shorthand.
@@ -119,7 +118,7 @@ module SCSSLint
     # @param bottom [String]
     # @param left [String]
     # @return [Boolean]
-    def condense_to_one_value?(top, right, bottom, left)
+    def condense_to_one_value?(top, right, bottom, left) # rubocop:disable Metrics/CyclomaticComplexity
       return unless allowed?(1)
       return unless top == right
 

--- a/lib/scss_lint/linter/space_between_parens.rb
+++ b/lib/scss_lint/linter/space_between_parens.rb
@@ -1,6 +1,4 @@
 module SCSSLint
-  # rubocop:disable Metrics/AbcSize
-
   # Checks for the presence of spaces between parentheses.
   class Linter::SpaceBetweenParens < Linter
     include LinterRegistry
@@ -33,7 +31,7 @@ module SCSSLint
 
     TRAILING_WHITESPACE = /\s*$/
 
-    def check(node, source) # rubocop:disable Metrics/MethodLength
+    def check(node, source) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       @spaces = config['spaces']
       source = trim_right_paren(source)
       return if source.count('(') != source.count(')')
@@ -71,7 +69,7 @@ module SCSSLint
     # An expression enclosed in parens will include or not include each paren, depending
     # on whitespace. Here we feel out for enclosing parens, and return them as the new
     # source for the node.
-    def feel_for_enclosing_parens(node) # rubocop:disable Metrics/CyclomaticComplexity
+    def feel_for_enclosing_parens(node) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       range = node.source_range
       original_source = source_from_range(range)
       left_offset = -1

--- a/lib/scss_lint/sass/script.rb
+++ b/lib/scss_lint/sass/script.rb
@@ -76,3 +76,5 @@ module Sass::Script
     end
   end
 end
+
+# rubocop:enable Documentation

--- a/lib/scss_lint/sass/tree.rb
+++ b/lib/scss_lint/sass/tree.rb
@@ -165,4 +165,6 @@ module Sass::Tree
       self.class == other.class && imported_filename == other.imported_filename && super
     end
   end
+
+  # rubocop:enable Documentation
 end


### PR DESCRIPTION
This PR fixes the RuboCop offences that are currently detected on the
RuboCop master branch. This will ease the removal of Ruby 2.0 support.