### PR TITLE
Add grid properties to SMACSS property order

### DIFF
--- a/data/property-sort-orders/smacss.txt
+++ b/data/property-sort-orders/smacss.txt
@@ -20,6 +20,31 @@ left
 
 box-sizing
 
+grid
+grid-after
+grid-area
+grid-auto-columns
+grid-auto-flow
+grid-auto-rows
+grid-before
+grid-column
+grid-column-end
+grid-column-gap
+grid-column-start
+grid-columns
+grid-end
+grid-gap
+grid-row
+grid-row-end
+grid-row-gap
+grid-row-start
+grid-rows
+grid-start
+grid-template
+grid-template-areas
+grid-template-columns
+grid-template-rows
+
 flex
 flex-basis
 flex-direction


### PR DESCRIPTION
Add next to flex box properties since they are related as layout properties.
Positioned before based on the idea that you're more likely to have flex box inside grid than the other way around.