### PR TITLE
Avoid to use sass v3.5.4

### DIFF
--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2'
 
   s.add_dependency 'rake', '>= 0.9', '< 13'
-  s.add_dependency 'sass', '~> 3.5.3'
+  s.add_dependency 'sass', '~> 3.5.3', '!= 3.5.4'
 end


### PR DESCRIPTION
Some test cases fail with sass v3.5.4, and the test does snot fail in v3.5.5.

with sass 3.5.3
----

```
$ bundle exec rspec
...
1764 examples, 0 failures
```

with sass 3.5.4
----

```
$ bundle exec rspec
...
1764 examples, 117 failures
```

with sass 3.5.5
----

```
$ bundle exec rspec
...
1764 examples, 0 failures
```

----

I guess it is sass gem's bug. So I think scss-lint should avoid sass v3.5.4.
  