### PR TITLE
Add `at_least_one_space_or_newline` option to SpaceAfterPropertyColon

### DIFF
--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -1519,7 +1519,7 @@ The `style` option allows you to specify a different preferred style.
 
 Configuration Option | Description
 ---------------------|---------------------------------------------------------
-`style`              | `one_space`, `no_space`, `at_least_one_space`, `one_space_or_newline`, or `aligned` (default **one_space**)
+`style`              | `one_space`, `no_space`, `one_space_or_newline`, `at_least_one_space`, `at_least_one_space_or_newline`, or `aligned` (default **one_space**)
 
 ## SpaceAfterPropertyName
 

--- a/lib/scss_lint/linter/README.md
+++ b/lib/scss_lint/linter/README.md
@@ -1519,7 +1519,7 @@ The `style` option allows you to specify a different preferred style.
 
 Configuration Option | Description
 ---------------------|---------------------------------------------------------
-`style`              | `one_space`, `no_space`, `one_space_or_newline`, `at_least_one_space`, `at_least_one_space_or_newline`, or `aligned` (default **one_space**)
+`style`              | `one_space`, `no_space`, `at_least_one_space`, `one_space_or_newline`, `at_least_one_space_or_newline`, or `aligned` (default **one_space**)
 
 ## SpaceAfterPropertyName
 

--- a/lib/scss_lint/linter/space_after_property_colon.rb
+++ b/lib/scss_lint/linter/space_after_property_colon.rb
@@ -24,6 +24,8 @@ module SCSSLint
         check_for_at_least_one_space(node, whitespace)
       when 'one_space_or_newline'
         check_for_one_space_or_newline(node, whitespace)
+      when 'at_least_one_space_or_newline'
+        check_for_at_least_one_space_or_newline(node, whitespace)
       end
 
       yield # Continue linting children
@@ -50,6 +52,12 @@ module SCSSLint
       return if [[' '], ["\n"]].include?(whitespace)
       return if whitespace[0] == "\n" && whitespace[1..-1].uniq == [' ']
       add_lint(node, 'Colon after property should be followed by one space or a newline')
+    end
+
+    def check_for_at_least_one_space_or_newline(node, whitespace)
+      return if [[' '], ["\n"]].include?(whitespace.uniq)
+      return if whitespace[0] == "\n" && whitespace[1..-1].uniq == [' ']
+      add_lint(node, 'Colon after property should be followed by at least one space or newline')
     end
 
     def check_properties_alignment(rule_node)

--- a/spec/scss_lint/linter/space_after_property_colon_spec.rb
+++ b/spec/scss_lint/linter/space_after_property_colon_spec.rb
@@ -266,11 +266,108 @@ describe SCSSLint::Linter::SpaceAfterPropertyColon do
       it { should_not report_lint }
     end
 
+    context 'when the colon after a property is followed by multiple spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:  bold;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
     context 'when the colon after a property is followed by a newline and spaces' do
       let(:scss) { <<-SCSS }
         p {
           background-image:
               url(https://something.crazy.long/with/paths?and=queries)
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is followed by a newline and no spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-image:
+url(https://something.crazy.long/with/paths?and=queries)
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is followed by a space and then a newline' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-image:\s
+url(https://something.crazy.long/with/paths?and=queries)
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+  end
+
+  context 'when at least one space or newline is preferred' do
+    let(:style) { 'at_least_one_space_or_newline' }
+
+    context 'when the colon after a property is not followed by space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:0;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when the colon after a property is followed by a space' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin: 0;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is surrounded by spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin : bold;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is followed by multiple spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:  bold;
+        }
+      SCSS
+
+      it { should_not report_lint }
+    end
+
+    context 'when the colon after a property is followed by multiple spaces and a tab' do
+      let(:scss) { <<-SCSS }
+        p {
+          margin:  \tbold;
+        }
+      SCSS
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when the colon after a property is followed by a newline and spaces' do
+      let(:scss) { <<-SCSS }
+        p {
+          background-image:
+            url(https://something.crazy.long/with/paths?and=queries)
         }
       SCSS
 


### PR DESCRIPTION
This rule would allow for the following:
```scss
height: 100px;
width:  100px;  // <-- multiple spaces

box-shadow:     // <-- newline
  inset 1px 1px 0 blue,
  0 0 5px red;
```

Currently, the `one_space_or_newline` option would complain about multiple spaces, and `at_least_one_space` would complain about the newline.