### PR TITLE
Allow Sass 3.6.0

### DIFF
--- a/scss_lint.gemspec
+++ b/scss_lint.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   s.add_dependency 'rake', '>= 0.9', '< 13'
-  s.add_dependency 'sass', '~> 3.5.5'
+  s.add_dependency 'sass', '~> 3.5', '>= 3.5.5'
 end


### PR DESCRIPTION
Allow Sass 3.6.0 as well with min. version of  3.5.5 for Sass


My Ruby/Gem versioning knowledge is shallow, so this may not be the correct solution for the problem at hand.


close #957