### PR TITLE
Fixed caret-color spelling

### DIFF
--- a/data/properties.txt
+++ b/data/properties.txt
@@ -125,7 +125,7 @@ break-before
 break-inside
 buffered-rendering
 caption-side
-carat-color
+caret-color
 clear
 clip
 clip-path


### PR DESCRIPTION
The `caret-color` property was typo'd as `carat-color`.